### PR TITLE
Allow using newer phpbench versions to benchmark laminas-stdlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpbench/phpbench": "^0.13",
+        "phpbench/phpbench": "^0.17.1",
         "phpunit/phpunit": "^9.3.7"
     },
     "autoload": {


### PR DESCRIPTION


<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Allow using newer phpbench versions to benchmark laminas-stdlib

https://getcomposer.org/doc/articles/versions.md#caret-version-range-

> For pre-1.0 versions it also acts with safety in mind and treats
> `^0.3` as `>=0.3.0 <0.4.0.`

Newer phpbench versions are required to fix bugs running phpbench in
php 8.

Alternately, I could try `<1.0`, but that may include breaking changes. 0.17 allowed me to run benchmarks.

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary - `phpbench` can't run in php 8 because it tries to `fread` from a temp file it opened with `fopen($path, 'w')`
  - TARGET THE master BRANCH
