### PR TITLE
PHPStan integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
         - CS_CHECK=true
         - BENCHMARKS=true
         - TEST_COVERAGE=true
+        - STATIC_ANALYSE=true
     - php: 7.2
       env:
         - DEPS=lowest
@@ -62,6 +63,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
+  - if [[ $STATIC_ANALYSE == 'true' ]]; then vendor/bin/phpstan analyze ; fi
   - if [[ $BENCHMARKS == 'true' ]]; then vendor/bin/phpbench run --revs=2 --iterations=2 --report=aggregate ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
-        "phpstan/phpstan": "^0.12.23"
+        "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "phpbench/phpbench": "^0.13",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+        "phpstan/phpstan": "0.12.23"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0",
+        "phpstan/phpstan": "^0.12.23"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20,3 +20,8 @@ parameters:
 			count: 1
 			path: src/ConsoleHelper.php
 
+		-
+			message: "#^Parameter \\#1 \\$error_handler of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, array\\(class\\-string\\<static\\(Laminas\\\\Stdlib\\\\ErrorHandler\\)\\>, 'addError'\\) given\\.$#"
+			count: 1
+			path: src/ErrorHandler.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#3 \\$flag of function array_filter expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/ArrayUtils.php
+
+		-
 			message: "#^Default value of the parameter \\#1 \\$resource \\(mixed\\) of method Laminas\\\\Stdlib\\\\ConsoleHelper\\:\\:__construct\\(\\) is incompatible with type resource\\.$#"
 			count: 1
 			path: src/ConsoleHelper.php
@@ -24,4 +29,19 @@ parameters:
 			message: "#^Parameter \\#1 \\$error_handler of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, array\\(class\\-string\\<static\\(Laminas\\\\Stdlib\\\\ErrorHandler\\)\\>, 'addError'\\) given\\.$#"
 			count: 1
 			path: src/ErrorHandler.php
+
+		-
+			message: "#^Method Laminas\\\\Stdlib\\\\StringWrapper\\\\AbstractStringWrapper\\:\\:getEncoding\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/StringWrapper/AbstractStringWrapper.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function iconv_substr expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/StringWrapper/Iconv.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/StringWrapper/Native.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,22 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Default value of the parameter \\#1 \\$resource \\(mixed\\) of method Laminas\\\\Stdlib\\\\ConsoleHelper\\:\\:__construct\\(\\) is incompatible with type resource\\.$#"
+			count: 1
+			path: src/ConsoleHelper.php
+
+		-
+			message: "#^Default value of the parameter \\#3 \\$resource \\(mixed\\) of method Laminas\\\\Stdlib\\\\ConsoleHelper\\:\\:write\\(\\) is incompatible with type resource\\.$#"
+			count: 1
+			path: src/ConsoleHelper.php
+
+		-
+			message: "#^Default value of the parameter \\#3 \\$resource \\(mixed\\) of method Laminas\\\\Stdlib\\\\ConsoleHelper\\:\\:writeLine\\(\\) is incompatible with type resource\\.$#"
+			count: 1
+			path: src/ConsoleHelper.php
+
+		-
+			message: "#^Default value of the parameter \\#1 \\$resource \\(mixed\\) of method Laminas\\\\Stdlib\\\\ConsoleHelper\\:\\:detectColorCapabilities\\(\\) is incompatible with type resource\\.$#"
+			count: 1
+			path: src/ConsoleHelper.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,4 +9,5 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
 
+    treatPhpDocTypesAsCertain: false
     inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,12 @@
+includes:
+    - phpstan-baseline.neon
+parameters:
+    level: max
+    parallel:
+        processTimeout: 180.0
+    fileExtensions:
+        - php
+    paths:
+        - %currentWorkingDirectory%/src
+
+    inferPrivatePropertyTypeFromConstructor: true

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -26,7 +26,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Constructor
      *
-     * @param  array|Traversable|null $options
+     * @param array<string, mixed>|Traversable<string, mixed>|null $options
      */
     public function __construct($options = null)
     {
@@ -38,7 +38,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Set one or more configuration properties
      *
-     * @param  array|Traversable|AbstractOptions $options
+     * @param  array<string, mixed>|Traversable<string, mixed>|AbstractOptions $options
      * @throws Exception\InvalidArgumentException
      * @return AbstractOptions Provides fluent interface
      */
@@ -70,7 +70,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Cast to array
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray()
     {

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -9,6 +9,7 @@
 namespace Laminas\Stdlib;
 
 use Traversable;
+use function get_object_vars;
 
 abstract class AbstractOptions implements ParameterObjectInterface
 {
@@ -78,7 +79,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
             $letter = array_shift($letters);
             return '_' . strtolower($letter);
         };
-        foreach ($this as $key => $value) {
+        foreach (get_object_vars($this) as $key => $value) {
             if ($key === '__strictMode__') {
                 continue;
             }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -94,7 +94,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     public function __set($key, $value)
     {
         if ($this->flag == self::ARRAY_AS_PROPS) {
-            return $this->offsetSet($key, $value);
+            $this->offsetSet($key, $value);
+            return;
         }
         if (in_array($key, $this->protectedProperties)) {
             throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
@@ -111,7 +112,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     public function __unset($key)
     {
         if ($this->flag == self::ARRAY_AS_PROPS) {
-            return $this->offsetUnset($key);
+            $this->offsetUnset($key);
+            return;
         }
         if (in_array($key, $this->protectedProperties)) {
             throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -17,6 +17,12 @@ use Serializable;
  * Custom framework ArrayObject implementation
  *
  * Extends version-specific "abstract" implementation.
+ *
+ * @phpstan-template TKey
+ * @phpstan-template TValue
+ *
+ * @phpstan-implements IteratorAggregate<int|TKey, TValue>
+ * @phpstan-implements ArrayAccess<int|TKey, TValue>
  */
 class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Countable
 {
@@ -33,6 +39,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
 
     /**
      * @var array
+     * @phpstan-var array<int|TKey, TValue>
      */
     protected $storage;
 
@@ -47,7 +54,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     protected $iteratorClass;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $protectedProperties;
 
@@ -57,6 +64,9 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param array  $input
      * @param int    $flags
      * @param string $iteratorClass
+     *
+     * @phpstan-param array<TKey, TValue> $input
+     * @phpstan-param class-string<\Iterator<TKey, TValue>> $iteratorClass
      */
     public function __construct($input = [], $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
     {
@@ -176,8 +186,11 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Exchange the array for another one.
      *
-     * @param  array|ArrayObject $data
+     * @param  array|\ArrayObject $data
      * @return array
+     *
+     * @phpstan-param array<TKey, TValue>|\ArrayObject<TKey, TValue> $data
+     * @phpstan-return array<int|TKey, TValue>
      */
     public function exchangeArray($data)
     {
@@ -205,6 +218,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * Creates a copy of the ArrayObject.
      *
      * @return array
+     * @phpstan-return array<int|TKey, TValue>
      */
     public function getArrayCopy()
     {
@@ -225,6 +239,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * Create a new iterator from an ArrayObject instance
      *
      * @return \Iterator
+     * @phpstan-return \Iterator<int|TKey, TValue>
      */
     public function getIterator()
     {

--- a/src/ArraySerializableInterface.php
+++ b/src/ArraySerializableInterface.php
@@ -8,6 +8,10 @@
 
 namespace Laminas\Stdlib;
 
+/**
+ * @phpstan-template TKey
+ * @phpstan-template TValue
+ */
 interface ArraySerializableInterface
 {
     /**
@@ -15,6 +19,8 @@ interface ArraySerializableInterface
      *
      * @param  array $array
      * @return void
+     *
+     * @phpstan-param array<TKey, TValue> $array
      */
     public function exchangeArray(array $array);
 
@@ -22,6 +28,8 @@ interface ArraySerializableInterface
      * Return an array representation of the object
      *
      * @return array
+     *
+     * @phpstan-return array<TKey, TValue>
      */
     public function getArrayCopy();
 }

--- a/src/ArrayStack.php
+++ b/src/ArrayStack.php
@@ -13,6 +13,10 @@ use ArrayObject as PhpArrayObject;
 
 /**
  * ArrayObject that acts as a stack with regards to iteration
+ *
+ * @phpstan-template TKey
+ * @phpstan-template TValue
+ * @phpstan-extends PhpArrayObject<TKey, TValue>
  */
 class ArrayStack extends PhpArrayObject
 {
@@ -23,6 +27,7 @@ class ArrayStack extends PhpArrayObject
      * ArrayIterator with that reversed array.
      *
      * @return ArrayIterator
+     * @phpstan-return ArrayIterator<TKey, TValue>
      */
     public function getIterator()
     {

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -181,7 +181,7 @@ abstract class ArrayUtils
      *
      * @param mixed $needle
      * @param array<mixed> $haystack
-     * @param int|bool $strict
+     * @param bool $strict
      * @return bool
      */
     public static function inArray($needle, array $haystack, $strict = false)
@@ -231,7 +231,7 @@ abstract class ArrayUtils
             return iterator_to_array($iterator);
         }
 
-        if (method_exists($iterator, 'toArray')) {
+        if ($iterator instanceof Traversable && method_exists($iterator, 'toArray')) {
             return $iterator->toArray();
         }
 
@@ -303,6 +303,7 @@ abstract class ArrayUtils
             }
         }
 
+        /** @phpstan-var array<TAKey|TBKey, TAValue|TBValue|mixed> */
         return $a;
     }
 

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -180,7 +180,7 @@ abstract class ArrayUtils
      * non-strict behaviour is used.
      *
      * @param mixed $needle
-     * @param array $haystack
+     * @param array<mixed> $haystack
      * @param int|bool $strict
      * @return bool
      */
@@ -211,6 +211,11 @@ abstract class ArrayUtils
      * @param  bool               $recursive    Recursively check all nested structures
      * @throws Exception\InvalidArgumentException if $iterator is not an array or a Traversable object
      * @return array
+     *
+     * @phpstan-template TKey
+     * @phpstan-template TValue
+     * @phpstan-param array<TKey, TValue>|Traversable<TKey, TValue> $iterator
+     * @phpstan-return array<TKey, TValue>
      */
     public static function iteratorToArray($iterator, $recursive = true)
     {
@@ -238,6 +243,7 @@ abstract class ArrayUtils
             }
 
             if ($value instanceof Traversable) {
+                /** @phpstan-ignore-next-line */
                 $array[$key] = static::iteratorToArray($value, $recursive);
                 continue;
             }
@@ -250,6 +256,7 @@ abstract class ArrayUtils
             $array[$key] = $value;
         }
 
+        /** @phpstan-var array<TKey, TValue> $array */
         return $array;
     }
 
@@ -260,10 +267,19 @@ abstract class ArrayUtils
      * from the second array will be appended to the first array. If both values are arrays, they
      * are merged together, else the value of the second array overwrites the one of the first array.
      *
+     * @phpstan-template TAKey
+     * @phpstan-template TAValue
+     * @phpstan-template TBKey
+     * @phpstan-template TBValue
+     *
      * @param  array $a
      * @param  array $b
      * @param  bool  $preserveNumericKeys
      * @return array
+     *
+     * @phpstan-param array<TAKey, TAValue> $a
+     * @phpstan-param array<TBKey, TBValue> $b
+     * @phpstan-return array<TAKey|TBKey, TAValue|TBValue>
      */
     public static function merge(array $a, array $b, $preserveNumericKeys = false)
     {
@@ -298,6 +314,12 @@ abstract class ArrayUtils
      * @param null|int $flag
      * @return array
      * @throws Exception\InvalidArgumentException
+     *
+     * @phpstan-template TDataKey
+     * @phpstan-template TDataValue
+     * @phpstan-param array<TDataKey, TDataValue> $data
+     * @phpstan-param callable(): bool $callback
+     * @phpstan-return array<TDataKey, TDataValue>
      */
     public static function filter(array $data, $callback, $flag = null)
     {

--- a/src/ArrayUtils/MergeReplaceKey.php
+++ b/src/ArrayUtils/MergeReplaceKey.php
@@ -8,6 +8,10 @@
 
 namespace Laminas\Stdlib\ArrayUtils;
 
+/**
+ * @phpstan-template TData
+ * @phpstan-implements MergeReplaceKeyInterface<TData>
+ */
 final class MergeReplaceKey implements MergeReplaceKeyInterface
 {
     /**
@@ -17,6 +21,7 @@ final class MergeReplaceKey implements MergeReplaceKeyInterface
 
     /**
      * @param mixed $data
+     * @phpstan-param TData $data
      */
     public function __construct($data)
     {

--- a/src/ArrayUtils/MergeReplaceKeyInterface.php
+++ b/src/ArrayUtils/MergeReplaceKeyInterface.php
@@ -10,11 +10,15 @@ namespace Laminas\Stdlib\ArrayUtils;
 
 /**
  * Marker interface: can be used to replace keys completely in {@see ArrayUtils::merge()} operations
+ *
+ * @phpstan-template TData
  */
 interface MergeReplaceKeyInterface
 {
     /**
      * @return mixed
+     *
+     * @phpstan-return TData
      */
     public function getData();
 }

--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -147,7 +147,7 @@ class ConsoleHelper
     /**
      * Ensure newlines are appropriate for the current terminal.
      *
-     * @param string
+     * @param string $string
      * @return string
      */
     private function formatNewlines($string)

--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -35,6 +35,7 @@ class ConsoleHelper
     const HIGHLIGHT_INFO  = 'info';
     const HIGHLIGHT_ERROR = 'error';
 
+    /** @var array<string, string> */
     private $highlightMap = [
         self::HIGHLIGHT_INFO  => self::COLOR_GREEN,
         self::HIGHLIGHT_ERROR => self::COLOR_RED,

--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -80,6 +80,7 @@ class ConsoleHelper
         foreach ($this->highlightMap as $key => $color) {
             $pattern = sprintf('#<%s>(.*?)</%s>#s', $key, $key);
             $color   = $this->supportsColor ? $color : '';
+            /** @var string $string */
             $string  = preg_replace($pattern, $color . '$1' . $reset, $string);
         }
         return $string;
@@ -154,6 +155,7 @@ class ConsoleHelper
     private function formatNewlines($string)
     {
         $string = str_replace($this->eol, "\0PHP_EOL\0", $string);
+        /** @var string $string */
         $string = preg_replace("/(\r\n|\n|\r)/", $this->eol, $string);
         return str_replace("\0PHP_EOL\0", $this->eol, $string);
     }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -51,7 +51,7 @@ abstract class ErrorHandler
     public static function start($errorLevel = \E_WARNING)
     {
         if (! static::$stack) {
-            set_error_handler([get_called_class(), 'addError'], $errorLevel);
+            set_error_handler([static::class, 'addError'], $errorLevel);
         }
 
         static::$stack[] = null;

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -19,7 +19,7 @@ abstract class ErrorHandler
     /**
      * Active stack
      *
-     * @var array
+     * @var array<mixed>
      */
     protected static $stack = [];
 
@@ -47,6 +47,7 @@ abstract class ErrorHandler
      * Starting the error handler
      *
      * @param int $errorLevel
+     * @return void
      */
     public static function start($errorLevel = \E_WARNING)
     {

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -20,6 +20,9 @@ use SplPriorityQueue as PhpSplPriorityQueue;
  * elements from the queue and it also acts like an Iterator without removing
  * the elements. This behaviour can be used in mixed scenarios with high
  * performance boost.
+ *
+ * @phpstan-template TValue
+ * @phpstan-implements Iterator<int, TValue>
  */
 class FastPriorityQueue implements Iterator, Countable, Serializable
 {
@@ -35,21 +38,21 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Elements of the queue, divided by priorities
      *
-     * @var array
+     * @var array<int, array<int, TValue>>
      */
     protected $values = [];
 
     /**
      * Array of priorities
      *
-     * @var array
+     * @var array<int, int>
      */
     protected $priorities = [];
 
     /**
      * Array of priorities used for the iteration
      *
-     * @var array
+     * @var array<int, int>
      */
     protected $subPriorities = [];
 
@@ -86,6 +89,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      *
      * @param mixed $value
      * @param integer $priority
+     * @return void
      */
     public function insert($value, $priority)
     {
@@ -128,6 +132,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      *
      * @param  mixed $datum
      * @return bool False if the item was not found, true otherwise.
+     *
+     * @phpstan-param TValue $datum
      */
     public function remove($datum)
     {
@@ -211,6 +217,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Set the iterator pointer to the next element in the queue
      * removing the previous element
+     *
+     * @return void
      */
     protected function nextAndRemove()
     {
@@ -232,6 +240,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Set the iterator pointer to the next element in the queue
      * without removing the previous element
+     *
+     * @return void
      */
     public function next()
     {
@@ -257,6 +267,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
 
     /**
      * Rewind the current iterator
+     * @return void
      */
     public function rewind()
     {
@@ -272,6 +283,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * Array will be priority => data pairs
      *
      * @return array
+     *
+     * @phpstan-return array<int, TValue>
      */
     public function toArray()
     {
@@ -317,6 +330,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * Set the extract flag
      *
      * @param integer $flag
+     * @return void
      */
     public function setExtractFlags($flag)
     {
@@ -346,6 +360,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      *
      * @param  mixed $datum
      * @return bool
+     *
+     * @phpstan-param TValue $datum
      */
     public function contains($datum)
     {

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -32,7 +32,7 @@ abstract class Glob
      * @param  string  $pattern
      * @param  int $flags
      * @param  bool $forceFallback
-     * @return array
+     * @return string[]
      * @throws Exception\RuntimeException
      */
     public static function glob($pattern, $flags = 0, $forceFallback = false)
@@ -49,7 +49,7 @@ abstract class Glob
      *
      * @param  string  $pattern
      * @param  int     $flags
-     * @return array
+     * @return string[]
      * @throws Exception\RuntimeException
      */
     protected static function systemGlob($pattern, $flags)
@@ -90,7 +90,7 @@ abstract class Glob
      *
      * @param  string  $pattern
      * @param  int     $flags
-     * @return array
+     * @return string[]
      * @throws Exception\RuntimeException
      */
     protected static function fallbackGlob($pattern, $flags)

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,7 +13,7 @@ use Traversable;
 class Message implements MessageInterface
 {
     /**
-     * @var array
+     * @var array<string|int, mixed>
      */
     protected $metadata = [];
 
@@ -28,7 +28,7 @@ class Message implements MessageInterface
      * Non-destructive setting of message metadata; always adds to the metadata, never overwrites
      * the entire metadata container.
      *
-     * @param  string|int|array|Traversable $spec
+     * @param  string|int|array<string|int, mixed>|Traversable<string|int, mixed> $spec
      * @param  mixed $value
      * @throws Exception\InvalidArgumentException
      * @return Message

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -13,8 +13,9 @@ interface MessageInterface
     /**
      * Set metadata
      *
-     * @param  string|int|array|\Traversable $spec
+     * @param  string|int|array<string|int, mixed>|\Traversable<string|int, mixed> $spec
      * @param  mixed $value
+     * @return $this
      */
     public function setMetadata($spec, $value = null);
 

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -10,6 +10,9 @@ namespace Laminas\Stdlib;
 
 use ArrayObject as PhpArrayObject;
 
+/**
+ * @phpstan-extends PhpArrayObject<string, mixed>
+ */
 class Parameters extends PhpArrayObject implements ParametersInterface
 {
     /**
@@ -18,7 +21,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * Enforces that we have an array, and enforces parameter access to array
      * elements.
      *
-     * @param  array $values
+     * @param array<string, mixed> $values
      */
     public function __construct(array $values = null)
     {
@@ -31,7 +34,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
     /**
      * Populate from native PHP array
      *
-     * @param  array $values
+     * @param  array<string, mixed> $values
      * @return void
      */
     public function fromArray(array $values)
@@ -55,7 +58,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
     /**
      * Serialize to native PHP array
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray()
     {
@@ -85,7 +88,8 @@ class Parameters extends PhpArrayObject implements ParametersInterface
         if ($this->offsetExists($name)) {
             return parent::offsetGet($name);
         }
-        return;
+
+        return null;
     }
 
     /**
@@ -104,7 +108,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
     /**
      * @param string $name
      * @param mixed $value
-     * @return Parameters
+     * @return $this
      */
     public function set($name, $value)
     {

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -42,7 +42,7 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      *
      * Allow deserialization from raw body; e.g., for PUT requests
      *
-     * @param $string
+     * @param string $string
      * @return mixed
      */
     public function fromString($string);

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -13,17 +13,20 @@ use Countable;
 use Serializable;
 use Traversable;
 
-/*
+/**
  * Basically, an ArrayObject. You could simply define something like:
  *     class QueryParams extends ArrayObject implements Parameters {}
  * and have 90% of the functionality
+ *
+ * @phpstan-extends ArrayAccess<string, mixed>
+ * @phpstan-extends Traversable<string, mixed>
  */
 interface ParametersInterface extends ArrayAccess, Countable, Serializable, Traversable
 {
     /**
      * Constructor
      *
-     * @param array $values
+     * @param array<string, mixed> $values
      */
     public function __construct(array $values = null);
 
@@ -32,8 +35,8 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      *
      * Allow deserialization from standard array
      *
-     * @param array $values
-     * @return mixed
+     * @param array<string, mixed> $values
+     * @return void
      */
     public function fromArray(array $values);
 
@@ -43,7 +46,7 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      * Allow deserialization from raw body; e.g., for PUT requests
      *
      * @param string $string
-     * @return mixed
+     * @return void
      */
     public function fromString($string);
 
@@ -52,7 +55,7 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      *
      * Allow serialization back to standard array
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
     public function toArray();
 
@@ -61,7 +64,7 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      *
      * Allow serialization to query format; e.g., for PUT or POST requests
      *
-     * @return mixed
+     * @return string
      */
     public function toString();
 

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -199,7 +199,10 @@ class PriorityList implements Iterator, Countable
      */
     public function current()
     {
-        $this->sorted || $this->sort();
+        if (false === $this->sorted) {
+            $this->sort();
+        }
+
         $node = current($this->items);
 
         return $node ? $node['data'] : false;
@@ -210,7 +213,10 @@ class PriorityList implements Iterator, Countable
      */
     public function key()
     {
-        $this->sorted || $this->sort();
+        if (false === $this->sorted) {
+            $this->sort();
+        }
+
         return key($this->items);
     }
 

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -225,8 +225,6 @@ class PriorityList implements Iterator, Countable
     }
 
     /**
-     * {@inheritDoc}
-     *
      * @phpstan-return string|null
      */
     public function key()
@@ -286,7 +284,7 @@ class PriorityList implements Iterator, Countable
      *
      * @return array
      *
-     * @phpstan-return array<string, array{data: TValue, priority: int, serial: int}>|array<string, int>|array<string, TValue>
+     * @phpstan-return array<string, array{data: TValue, priority: int, serial: int}|int|TValue>
      */
     public function toArray($flag = self::EXTR_DATA)
     {

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -11,6 +11,10 @@ namespace Laminas\Stdlib;
 use Countable;
 use Iterator;
 
+/**
+ * @phpstan-template TValue
+ * @phpstan-implements Iterator<string, TValue>
+ */
 class PriorityList implements Iterator, Countable
 {
     const EXTR_DATA     = 0x00000001;
@@ -20,6 +24,7 @@ class PriorityList implements Iterator, Countable
      * Internal list of all items.
      *
      * @var array[]
+     * @phpstan-var array<string, array{data: TValue, priority: int, serial: int}>
      */
     protected $items = [];
 
@@ -58,6 +63,8 @@ class PriorityList implements Iterator, Countable
      * @param  int     $priority
      *
      * @return void
+     *
+     * @phpstan-param TValue $value
      */
     public function insert($name, $value, $priority = 0)
     {
@@ -127,11 +134,13 @@ class PriorityList implements Iterator, Countable
      *
      * @param  string $name
      * @return mixed
+     *
+     * @phpstan-return TValue|null
      */
     public function get($name)
     {
         if (! isset($this->items[$name])) {
-            return;
+            return null;
         }
 
         return $this->items[$name]['data'];
@@ -156,6 +165,9 @@ class PriorityList implements Iterator, Countable
      * @param  array $item1,
      * @param  array $item2
      * @return int
+     *
+     * @phpstan-param array<string, array{data: TValue, priority: int, serial: int}> $item1
+     * @phpstan-param array<string, array{data: TValue, priority: int, serial: int}> $item2
      */
     protected function compare(array $item1, array $item2)
     {
@@ -187,6 +199,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @return void
      */
     public function rewind()
     {
@@ -196,6 +210,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @phpstan-return TValue|bool
      */
     public function current()
     {
@@ -210,6 +226,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @phpstan-return string|null
      */
     public function key()
     {
@@ -222,6 +240,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @phpstan-return TValue|bool
      */
     public function next()
     {
@@ -232,6 +252,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool
      */
     public function valid()
     {
@@ -240,6 +262,7 @@ class PriorityList implements Iterator, Countable
 
     /**
      * @return self
+     * @phpstan-return PriorityList<TValue>
      */
     public function getIterator()
     {
@@ -248,6 +271,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * {@inheritDoc}
+     *
+     * @return int
      */
     public function count()
     {
@@ -260,6 +285,8 @@ class PriorityList implements Iterator, Countable
      * @param int $flag
      *
      * @return array
+     *
+     * @phpstan-return array<string, array{data: TValue, priority: int, serial: int}>|array<string, int>|array<string, TValue>
      */
     public function toArray($flag = self::EXTR_DATA)
     {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -23,6 +23,9 @@ use Serializable;
  * This class aggregates items for the queue itself, but also composes an
  * "inner" iterator in the form of an SplPriorityQueue object for performing
  * the actual iteration.
+ *
+ * @phpstan-template TValue
+ * @phpstan-implements IteratorAggregate<string, TValue>
  */
 class PriorityQueue implements Countable, IteratorAggregate, Serializable
 {
@@ -40,6 +43,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Actual items aggregated in the priority queue. Each item is an array
      * with keys "data" and "priority".
      * @var array
+     * @phpstan-var array<int, array{data: TValue, priority: int}>
      */
     protected $items      = [];
 
@@ -56,7 +60,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param  mixed $data
      * @param  int $priority
-     * @return PriorityQueue
+     * @return $this
      */
     public function insert($data, $priority = 1)
     {
@@ -84,6 +88,8 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param  mixed $datum
      * @return bool False if the item was not found, true otherwise.
+     *
+     * @phpstan-param TValue $datum
      */
     public function remove($datum)
     {
@@ -203,6 +209,8 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param  int $flag
      * @return array
+     *
+     * @phpstan-return array<int, array{data: TValue, priority: int}>|array<int, int>|array<int, TValue>
      */
     public function toArray($flag = self::EXTR_DATA)
     {
@@ -228,7 +236,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * internal queue class. The class provided should extend SplPriorityQueue.
      *
      * @param  string $class
-     * @return PriorityQueue
+     * @return $this
      */
     public function setInternalQueueClass($class)
     {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -34,7 +34,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Inner queue class to use for iteration
      * @var string
      */
-    protected $queueClass = 'Laminas\Stdlib\SplPriorityQueue';
+    protected $queueClass = SplPriorityQueue::class;
 
     /**
      * Actual items aggregated in the priority queue. Each item is an array
@@ -45,7 +45,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
 
     /**
      * Inner queue object
-     * @var SplPriorityQueue
+     * @var \SplPriorityQueue|null
      */
     protected $queue;
 
@@ -88,6 +88,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     public function remove($datum)
     {
         $found = false;
+        $key = null;
         foreach ($this->items as $key => $item) {
             if ($item['data'] === $datum) {
                 $found = true;
@@ -159,11 +160,12 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * retrieves the inner queue object, and clones it for purposes of
      * iteration.
      *
-     * @return SplPriorityQueue
+     * @return \SplPriorityQueue
      */
     public function getIterator()
     {
         $queue = $this->getQueue();
+
         return clone $queue;
     }
 
@@ -270,19 +272,22 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Get the inner priority queue instance
      *
      * @throws Exception\DomainException
-     * @return SplPriorityQueue
+     * @return \SplPriorityQueue
      */
     protected function getQueue()
     {
-        if (null === $this->queue) {
-            $this->queue = new $this->queueClass();
-            if (! $this->queue instanceof \SplPriorityQueue) {
-                throw new Exception\DomainException(sprintf(
-                    'PriorityQueue expects an internal queue of type SplPriorityQueue; received "%s"',
-                    get_class($this->queue)
-                ));
-            }
+        if (null !== $this->queue) {
+            return $this->queue;
         }
+
+        $this->queue = new $this->queueClass();
+        if (! $this->queue instanceof \SplPriorityQueue) {
+            throw new Exception\DomainException(sprintf(
+                'PriorityQueue expects an internal queue of type SplPriorityQueue; received "%s"',
+                get_class($this->queue)
+            ));
+        }
+
         return $this->queue;
     }
 

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -15,6 +15,8 @@ use Serializable;
  *
  * Also, provides predictable heap order for datums added with the same priority
  * (i.e., they will be emitted in the same order they are enqueued).
+ *
+ * @phpstan-template T
  */
 class SplPriorityQueue extends \SplPriorityQueue implements Serializable
 {
@@ -32,6 +34,8 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      * @param  mixed $datum
      * @param  mixed $priority
      * @return bool
+     *
+     * @phpstan-param T $datum
      */
     public function insert($datum, $priority)
     {
@@ -48,6 +52,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      * Array will be priority => data pairs
      *
      * @return array
+     * @phpstan-return array<int, T>
      */
     public function toArray()
     {

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -31,14 +31,15 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      *
      * @param  mixed $datum
      * @param  mixed $priority
-     * @return void
+     * @return bool
      */
     public function insert($datum, $priority)
     {
         if (! is_array($priority)) {
             $priority = [$priority, $this->serial--];
         }
-        parent::insert($datum, $priority);
+
+        return parent::insert($datum, $priority);
     }
 
     /**

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -12,6 +12,8 @@ use Serializable;
 
 /**
  * Serializable version of SplQueue
+ *
+ * @phpstan-template TValue
  */
 class SplQueue extends \SplQueue implements Serializable
 {
@@ -19,6 +21,7 @@ class SplQueue extends \SplQueue implements Serializable
      * Return an array representing the queue
      *
      * @return array
+     * @phpstan-return array<int, TValue>
      */
     public function toArray()
     {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -12,6 +12,8 @@ use Serializable;
 
 /**
  * Serializable version of SplStack
+ *
+ * @phpstan-template TValue
  */
 class SplStack extends \SplStack implements Serializable
 {
@@ -19,6 +21,7 @@ class SplStack extends \SplStack implements Serializable
      * Serialize to an array representing the stack
      *
      * @return array
+     * @phpstan-return array<int, TValue>
      */
     public function toArray()
     {

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -21,7 +21,8 @@ abstract class StringUtils
     /**
      * Ordered list of registered string wrapper instances
      *
-     * @var StringWrapperInterface[]|null
+     * @var string[]|null
+     * @phpstan-var array<class-string<StringWrapperInterface>>|null
      */
     protected static $wrapperRegistry = null;
 
@@ -50,6 +51,7 @@ abstract class StringUtils
      * Get registered wrapper classes
      *
      * @return string[]
+     * @phpstan-return array<class-string<StringWrapperInterface>>
      */
     public static function getRegisteredWrappers()
     {
@@ -79,6 +81,8 @@ abstract class StringUtils
      *
      * @param string $wrapper
      * @return void
+     *
+     * @phpstan-param class-string<StringWrapperInterface> $wrapper
      */
     public static function registerWrapper($wrapper)
     {

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -21,7 +21,7 @@ abstract class StringUtils
     /**
      * Ordered list of registered string wrapper instances
      *
-     * @var StringWrapperInterface[]
+     * @var StringWrapperInterface[]|null
      */
     protected static $wrapperRegistry = null;
 
@@ -42,7 +42,7 @@ abstract class StringUtils
     /**
      * Is PCRE compiled with Unicode support?
      *
-     * @var bool
+     * @var bool|null
      **/
     protected static $hasPcreUnicodeSupport = null;
 

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -87,7 +87,7 @@ abstract class StringUtils
     public static function registerWrapper($wrapper)
     {
         $wrapper = (string) $wrapper;
-        if (! in_array($wrapper, static::$wrapperRegistry, true)) {
+        if (! in_array($wrapper, static::$wrapperRegistry ?: [], true)) {
             static::$wrapperRegistry[] = $wrapper;
         }
     }
@@ -97,10 +97,12 @@ abstract class StringUtils
      *
      * @param string $wrapper
      * @return void
+     *
+     * @phpstan-param class-string<StringWrapperInterface> $wrapper
      */
     public static function unregisterWrapper($wrapper)
     {
-        $index = array_search((string) $wrapper, static::$wrapperRegistry, true);
+        $index = array_search((string) $wrapper, static::$wrapperRegistry ?: [], true);
         if ($index !== false) {
             unset(static::$wrapperRegistry[$index]);
         }

--- a/src/StringWrapper/AbstractStringWrapper.php
+++ b/src/StringWrapper/AbstractStringWrapper.php
@@ -240,13 +240,13 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
             return $input;
         }
 
-        $repeatCount = floor($lengthOfPadding / $padStringLength);
+        $repeatCount = (int) floor($lengthOfPadding / $padStringLength);
 
         if ($padType === STR_PAD_BOTH) {
             $repeatCountLeft = $repeatCountRight = ($repeatCount - $repeatCount % 2) / 2;
 
             $lastStringLength       = $lengthOfPadding - 2 * $repeatCountLeft * $padStringLength;
-            $lastStringLeftLength   = $lastStringRightLength = floor($lastStringLength / 2);
+            $lastStringLeftLength   = $lastStringRightLength = (int) floor($lastStringLength / 2);
             $lastStringRightLength += $lastStringLength % 2;
 
             $lastStringLeft  = $this->substr($padString, 0, $lastStringLeftLength);

--- a/src/StringWrapper/AbstractStringWrapper.php
+++ b/src/StringWrapper/AbstractStringWrapper.php
@@ -164,8 +164,8 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
             return wordwrap($string, $width, $break, $cut);
         }
 
-        $stringWidth = $this->strlen($string);
-        $breakWidth  = $this->strlen($break);
+        $stringWidth = $this->strlen($string) ?: null;
+        $breakWidth  = $this->strlen($break) ?: null;
 
         $result    = '';
         $lastStart = $lastSpace = 0;

--- a/src/StringWrapper/MbString.php
+++ b/src/StringWrapper/MbString.php
@@ -27,17 +27,19 @@ class MbString extends AbstractStringWrapper
      */
     public static function getSupportedEncodings()
     {
-        if (static::$encodings === null) {
-            static::$encodings = array_map('strtoupper', mb_list_encodings());
-
-            // FIXME: Converting € (UTF-8) to ISO-8859-16 gives a wrong result
-            $indexIso885916 = array_search('ISO-8859-16', static::$encodings, true);
-            if ($indexIso885916 !== false) {
-                unset(static::$encodings[$indexIso885916]);
-            }
+        if (null !== static::$encodings) {
+            return static::$encodings;
         }
 
-        return static::$encodings;
+        $encodings = array_map('strtoupper', mb_list_encodings());
+
+        // FIXME: Converting € (UTF-8) to ISO-8859-16 gives a wrong result
+        $indexIso885916 = array_search('ISO-8859-16', $encodings, true);
+        if ($indexIso885916 !== false) {
+            unset($encodings[$indexIso885916]);
+        }
+
+        return static::$encodings = $encodings;
     }
 
     /**

--- a/src/StringWrapper/Native.php
+++ b/src/StringWrapper/Native.php
@@ -74,7 +74,7 @@ class Native extends AbstractStringWrapper
             );
         }
 
-        if ($encodingUpper !== strtoupper($convertEncoding)) {
+        if ($encodingUpper !== strtoupper($convertEncoding ?: '')) {
             $this->convertEncoding = $encodingUpper;
         }
 

--- a/src/StringWrapper/StringWrapperInterface.php
+++ b/src/StringWrapper/StringWrapperInterface.php
@@ -16,6 +16,7 @@ interface StringWrapperInterface
      *
      * @param string      $encoding
      * @param string|null $convertEncoding
+     * @return bool
      */
     public static function isSupported($encoding, $convertEncoding = null);
 

--- a/test/GlobTest.php
+++ b/test/GlobTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\Stdlib;
 use Laminas\Stdlib\Exception\RuntimeException;
 use Laminas\Stdlib\Glob;
 use PHPUnit\Framework\TestCase;
+use function var_dump;
 
 class GlobTest extends TestCase
 {


### PR DESCRIPTION
**PHPStan integration*

Fixed code and type annotations for static analyze.
Some errors are ignored in `phpstan-baseline.neon`.

This is a library used in many components, so I decided to start from this. The static analyze will help us to improve and fix type hints and then migrate to a type stricter code.

Can someone review it?