### PR TITLE
Ensure PriorityQueue::extract also removes item from internal list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "phpbench/phpbench": "^0.17.1",
-        "phpunit/phpunit": "^9.3.7"
+        "phpunit/phpunit": "~9.3.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-stdlib Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -41,7 +41,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Inner queue class to use for iteration
      * @var string
      */
-    protected $queueClass = 'Laminas\Stdlib\SplPriorityQueue';
+    protected $queueClass = SplPriorityQueue::class;
 
     /**
      * Actual items aggregated in the priority queue. Each item is an array
@@ -153,7 +153,34 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      */
     public function extract()
     {
-        return $this->getQueue()->extract();
+        $value = $this->getQueue()->extract();
+
+        $keyToRemove = null;
+        $highestPriority = null;
+        foreach ($this->items as $key => $item) {
+            if ($item['data'] !== $value) {
+                continue;
+            }
+
+            if (null === $highestPriority) {
+                $highestPriority = $item['priority'];
+                $keyToRemove = $key;
+                continue;
+            }
+
+            if ($highestPriority >= $item['priority']) {
+                continue;
+            }
+
+            $highestPriority = $item['priority'];
+            $keyToRemove = $key;
+        }
+
+        if ($keyToRemove !== null) {
+            unset($this->items[$keyToRemove]);
+        }
+
+        return $value;
     }
 
     /**

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -181,4 +181,34 @@ class PriorityQueueTest extends TestCase
 
         $this->assertCount(1, $queue);
     }
+
+    /**
+     * @see https://github.com/laminas/laminas-stdlib/issues/12
+     */
+    public function testTopValueNotFoundAfterExtractingTopElement(): void
+    {
+        $queue = new PriorityQueue();
+        $queue->insert('first');
+        $queue->insert('second');
+
+        $queue->extract();
+
+        $this->assertFalse($queue->contains('first'));
+    }
+
+    /**
+     * @see https://github.com/laminas/laminas-stdlib/issues/12
+     */
+    public function testValueStillFoundAfterExtractingTopElementWhenItIsADuplicate(): void
+    {
+        $queue = new PriorityQueue();
+        $queue->insert('first');
+        $queue->insert('second');
+        $queue->insert('first');
+
+        $queue->extract();
+
+        $this->assertCount(2, $queue);
+        $this->assertTrue($queue->contains('first'));
+    }
 }

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -167,4 +167,18 @@ class PriorityQueueTest extends TestCase
 
         self::assertEquals($queue, $testQueue);
     }
+
+    /**
+     * @see https://github.com/laminas/laminas-stdlib/issues/12
+     */
+    public function testUpdatesCountAfterExtractingTopElement(): void
+    {
+        $queue = new PriorityQueue();
+        $queue->insert('first');
+        $queue->insert('second');
+
+        $queue->extract();
+
+        $this->assertCount(1, $queue);
+    }
 }


### PR DESCRIPTION
The behavior of `Laminas\Stdlib\PriorityQueue::extract()` was such that it simply proxied to the underlying `SplPriorityQueue` implementation.

However, the class adds a number of additional behaviors such as `count()`, `contains()`, and `hasPriority()` that operate on an internal array of items instead of the `SplPriorityQueue` instance. As such, calling `extract()` would leave the `PriorityQueue` in an invalid state (count would not decrease, value would still be found, etc.).

This patch adds logic to `extract()` to find the matching value in the internal `$items` array with the highest priority and then remove it before returning the value.

Fixes #12
