### PR TITLE
Fix #15 [Breaking Change]: use same behavior of system glob

### DIFF
--- a/src/Glob.php
+++ b/src/Glob.php
@@ -111,7 +111,7 @@ abstract class Glob
      */
     protected static function fallbackGlob($pattern, $flags)
     {
-        if (! $flags & self::GLOB_BRACE) {
+        if (! ($flags & self::GLOB_BRACE)) {
             return static::systemGlob($pattern, $flags);
         }
 
@@ -145,7 +145,7 @@ abstract class Glob
         $next = static::nextBraceSub($pattern, $begin + 1, $flags);
 
         if ($next === null) {
-            return static::systemGlob($pattern, $flags);
+            static::systemGlob($pattern, $flags);
         }
 
         $rest = $next;
@@ -154,7 +154,7 @@ abstract class Glob
             $rest = static::nextBraceSub($pattern, $rest + 1, $flags);
 
             if ($rest === null) {
-                return static::systemGlob($pattern, $flags);
+                static::systemGlob($pattern, $flags);
             }
         }
 
@@ -179,6 +179,10 @@ abstract class Glob
             $next = static::nextBraceSub($pattern, $p, $flags);
         }
 
+        if (! ($flags & self::GLOB_NOSORT)) {
+            sort($paths);
+        }
+
         return array_unique($paths);
     }
 
@@ -197,7 +201,7 @@ abstract class Glob
         $current = $begin;
 
         while ($current < $length) {
-            if (! $flags & self::GLOB_NOESCAPE && $pattern[$current] === '\\') {
+            if (! ($flags & self::GLOB_NOESCAPE) && $pattern[$current] === '\\') {
                 if (++$current === $length) {
                     break;
                 }


### PR DESCRIPTION
Fix #15: Fixed operator precedence comparing flags on Glob.

**Breaking change**: it should be released in a next major version.

This will fix the wrong condition when comparing flags, allowing the use of system glob function when `GLOB_BRACE` is available (right now it will always use the fallback).
This will also fix the fallback method to use the same behaviour of the system `glob` function.

The fix will cause a breaking change, changing the behavior.
Right now, when `GLOB_BRACE` is used in flags, the behaviour is almost the same of using `GLOB_BRACE | GLOB_NOSORT` flags. Fallback method is fixed to correctly sort results when `GLOB_NOSORT` is used.

I would suggest to add a `E_USER_DEPRECATED` error in the current release with a warning of the future change behaviour when using `GLOB_BRACE` without `GLOB_NOSORT`.