### PR TITLE
Allow null argument to strlen

### DIFF
--- a/src/StringWrapper/Intl.php
+++ b/src/StringWrapper/Intl.php
@@ -47,11 +47,15 @@ class Intl extends AbstractStringWrapper
     /**
      * Returns the length of the given string
      *
-     * @param string $str
+     * @param string|null $str
      * @return false|int
      */
     public function strlen($str)
     {
+        if ($str === null) {
+            return false;
+        }
+
         $len = grapheme_strlen($str);
         return $len ?? false;
     }

--- a/src/StringWrapper/Intl.php
+++ b/src/StringWrapper/Intl.php
@@ -53,7 +53,7 @@ class Intl extends AbstractStringWrapper
     public function strlen($str)
     {
         if ($str === null) {
-            return false;
+            return 0;
         }
 
         $len = grapheme_strlen($str);


### PR DESCRIPTION
Resolves a BC break introduced in 3.4.0
A Fatal Error is thrown when null is passed to StringWrapper/Intl:strlen which was not the case in previous versions

Closes #29