### PR TITLE
Stricter typehints matching doc block hints

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -68,10 +68,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * Constructor
      *
      * @param array|object $input Object values must act like ArrayAccess
-     * @param int          $flags
-     * @param string       $iteratorClass
      */
-    public function __construct($input = [], $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
+    public function __construct($input = [], int $flags = self::STD_PROP_LIST, string $iteratorClass = 'ArrayIterator')
     {
         $this->setFlags($flags);
         $this->storage = $input;
@@ -373,10 +371,9 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Sets the behavior flags
      *
-     * @param  int  $flags
      * @return void
      */
-    public function setFlags($flags)
+    public function setFlags(int $flags)
     {
         $this->flag = $flags;
     }
@@ -384,10 +381,9 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Sets the iterator classname for the ArrayObject
      *
-     * @param  string $class
      * @return void
      */
-    public function setIteratorClass($class)
+    public function setIteratorClass(string $class)
     {
         if (class_exists($class)) {
             $this->iteratorClass = $class;

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -49,7 +49,7 @@ abstract class ArrayUtils
      * @param  bool  $allowEmpty    Should an empty array() return true
      * @return bool
      */
-    public static function hasStringKeys($value, $allowEmpty = false)
+    public static function hasStringKeys($value, bool $allowEmpty = false)
     {
         if (! is_array($value)) {
             return false;
@@ -69,7 +69,7 @@ abstract class ArrayUtils
      * @param  bool  $allowEmpty    Should an empty array() return true
      * @return bool
      */
-    public static function hasIntegerKeys($value, $allowEmpty = false)
+    public static function hasIntegerKeys($value, bool $allowEmpty = false)
     {
         if (! is_array($value)) {
             return false;
@@ -96,7 +96,7 @@ abstract class ArrayUtils
      * @param  bool  $allowEmpty    Should an empty array() return true
      * @return bool
      */
-    public static function hasNumericKeys($value, $allowEmpty = false)
+    public static function hasNumericKeys($value, bool $allowEmpty = false)
     {
         if (! is_array($value)) {
             return false;
@@ -129,7 +129,7 @@ abstract class ArrayUtils
      * @param  bool  $allowEmpty    Is an empty list a valid list?
      * @return bool
      */
-    public static function isList($value, $allowEmpty = false)
+    public static function isList($value, bool $allowEmpty = false)
     {
         if (! is_array($value)) {
             return false;
@@ -171,7 +171,7 @@ abstract class ArrayUtils
      * @param  bool  $allowEmpty    Is an empty array() a valid hash table?
      * @return bool
      */
-    public static function isHashTable($value, $allowEmpty = false)
+    public static function isHashTable($value, bool $allowEmpty = false)
     {
         if (! is_array($value)) {
             return false;
@@ -226,7 +226,7 @@ abstract class ArrayUtils
      * @throws Exception\InvalidArgumentException If $iterator is not an array or a Traversable object.
      * @return array
      */
-    public static function iteratorToArray($iterator, $recursive = true)
+    public static function iteratorToArray($iterator, bool $recursive = true)
     {
         if (! is_array($iterator) && ! $iterator instanceof Traversable) {
             throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable object');
@@ -276,10 +276,9 @@ abstract class ArrayUtils
      *
      * @param  array $a
      * @param  array $b
-     * @param  bool  $preserveNumericKeys
      * @return array
      */
-    public static function merge(array $a, array $b, $preserveNumericKeys = false)
+    public static function merge(array $a, array $b, bool $preserveNumericKeys = false)
     {
         foreach ($b as $key => $value) {
             if ($value instanceof MergeReplaceKeyInterface) {
@@ -309,11 +308,10 @@ abstract class ArrayUtils
      *
      * @param array $data
      * @param callable $callback
-     * @param null|int $flag
      * @return array
      * @throws Exception\InvalidArgumentException
      */
-    public static function filter(array $data, $callback, $flag = null)
+    public static function filter(array $data, $callback, ?int $flag = null)
     {
         if (! is_callable($callback)) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/src/ConsoleHelper.php
+++ b/src/ConsoleHelper.php
@@ -77,10 +77,9 @@ class ConsoleHelper
      * $highlightMap; if color support is disabled, simply removes the formatting
      * tags.
      *
-     * @param string $string
      * @return string
      */
-    public function colorize($string)
+    public function colorize(string $string)
     {
         $reset = $this->supportsColor ? self::COLOR_RESET : '';
         foreach ($this->highlightMap as $key => $color) {
@@ -92,12 +91,10 @@ class ConsoleHelper
     }
 
     /**
-     * @param string $string
-     * @param bool $colorize Whether or not to colorize the string
      * @param resource $resource Defaults to STDOUT
      * @return void
      */
-    public function write($string, $colorize = true, $resource = STDOUT)
+    public function write(string $string, bool $colorize = true, $resource = STDOUT)
     {
         if ($colorize) {
             $string = $this->colorize($string);
@@ -109,12 +106,10 @@ class ConsoleHelper
     }
 
     /**
-     * @param string $string
-     * @param bool $colorize Whether or not to colorize the line
      * @param resource $resource Defaults to STDOUT
      * @return void
      */
-    public function writeLine($string, $colorize = true, $resource = STDOUT)
+    public function writeLine(string $string, bool $colorize = true, $resource = STDOUT)
     {
         $this->write($string . $this->eol, $colorize, $resource);
     }
@@ -126,10 +121,9 @@ class ConsoleHelper
      * using STDERR as the resource; emits an additional empty line when done,
      * also to STDERR.
      *
-     * @param string $message
      * @return void
      */
-    public function writeErrorMessage($message)
+    public function writeErrorMessage(string $message)
     {
         $this->writeLine(sprintf('<error>%s</error>', $message), true, $this->stderr);
         $this->writeLine('', false, $this->stderr);
@@ -154,10 +148,9 @@ class ConsoleHelper
     /**
      * Ensure newlines are appropriate for the current terminal.
      *
-     * @param string $string
      * @return string
      */
-    private function formatNewlines($string)
+    private function formatNewlines(string $string)
     {
         $string = str_replace($this->eol, "\0PHP_EOL\0", $string);
         $string = preg_replace("/(\r\n|\n|\r)/", $this->eol, $string);

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -50,10 +50,9 @@ abstract class ErrorHandler
     /**
      * Starting the error handler
      *
-     * @param int $errorLevel
      * @return void
      */
-    public static function start($errorLevel = E_WARNING)
+    public static function start(int $errorLevel = E_WARNING)
     {
         if (! static::$stack) {
             set_error_handler([static::class, 'addError'], $errorLevel);
@@ -65,11 +64,10 @@ abstract class ErrorHandler
     /**
      * Stopping the error handler
      *
-     * @param  bool $throw Throw the ErrorException if any
      * @return null|ErrorException
      * @throws ErrorException If an error has been caught and $throw is true.
      */
-    public static function stop($throw = false)
+    public static function stop(bool $throw = false)
     {
         $errorException = null;
 
@@ -105,13 +103,9 @@ abstract class ErrorHandler
     /**
      * Add an error to the stack
      *
-     * @param int    $errno
-     * @param string $errstr
-     * @param string $errfile
-     * @param int    $errline
      * @return void
      */
-    public static function addError($errno, $errstr = '', $errfile = '', $errline = 0)
+    public static function addError(int $errno, string $errstr = '', string $errfile = '', int $errline = 0)
     {
         $stack = &static::$stack[count(static::$stack) - 1];
         $stack = new ErrorException($errstr, 0, $errno, $errfile, $errline, $stack);

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -43,13 +43,10 @@ abstract class Glob
      *
      * @see    http://docs.php.net/glob
      *
-     * @param  string  $pattern
-     * @param  int $flags
-     * @param  bool $forceFallback
      * @return array
      * @throws Exception\RuntimeException
      */
-    public static function glob($pattern, $flags = 0, $forceFallback = false)
+    public static function glob(string $pattern, int $flags = 0, bool $forceFallback = false)
     {
         if (! defined('GLOB_BRACE') || $forceFallback) {
             return static::fallbackGlob($pattern, $flags);
@@ -61,12 +58,10 @@ abstract class Glob
     /**
      * Use the glob function provided by the system.
      *
-     * @param  string  $pattern
-     * @param  int     $flags
      * @return array
      * @throws Exception\RuntimeException
      */
-    protected static function systemGlob($pattern, $flags)
+    protected static function systemGlob(string $pattern, int $flags)
     {
         if ($flags) {
             $flagMap = [
@@ -102,12 +97,10 @@ abstract class Glob
     /**
      * Expand braces manually, then use the system glob.
      *
-     * @param  string  $pattern
-     * @param  int     $flags
      * @return array
      * @throws Exception\RuntimeException
      */
-    protected static function fallbackGlob($pattern, $flags)
+    protected static function fallbackGlob(string $pattern, int $flags)
     {
         if (! $flags & self::GLOB_BRACE) {
             return static::systemGlob($pattern, $flags);
@@ -183,12 +176,9 @@ abstract class Glob
     /**
      * Find the end of the sub-pattern in a brace expression.
      *
-     * @param  string  $pattern
-     * @param  int $begin
-     * @param  int $flags
      * @return int|null
      */
-    protected static function nextBraceSub($pattern, $begin, $flags)
+    protected static function nextBraceSub(string $pattern, int $begin, int $flags)
     {
         $length  = strlen($pattern);
         $depth   = 0;

--- a/src/Guard/ArrayOrTraversableGuardTrait.php
+++ b/src/Guard/ArrayOrTraversableGuardTrait.php
@@ -6,11 +6,10 @@ namespace Laminas\Stdlib\Guard;
 
 use Exception;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
-use Traversable;
 
 use function get_class;
 use function gettype;
-use function is_array;
+use function is_iterable;
 use function is_object;
 use function sprintf;
 
@@ -23,17 +22,15 @@ trait ArrayOrTraversableGuardTrait
      * Verifies that the data is an array or Traversable
      *
      * @param mixed  $data           the data to verify
-     * @param string $dataName       the data name
-     * @param string $exceptionClass FQCN for the exception
      * @return void
      * @throws Exception
      */
     protected function guardForArrayOrTraversable(
         $data,
-        $dataName = 'Argument',
-        $exceptionClass = InvalidArgumentException::class
+        string $dataName = 'Argument',
+        string $exceptionClass = InvalidArgumentException::class
     ) {
-        if (! is_array($data) && ! $data instanceof Traversable) {
+        if (! is_iterable($data)) {
             $message = sprintf(
                 "%s must be an array or Traversable, [%s] given",
                 $dataName,

--- a/src/Guard/EmptyGuardTrait.php
+++ b/src/Guard/EmptyGuardTrait.php
@@ -18,15 +18,13 @@ trait EmptyGuardTrait
      * Verify that the data is not empty
      *
      * @param mixed  $data           the data to verify
-     * @param string $dataName       the data name
-     * @param string $exceptionClass FQCN for the exception
      * @return void
      * @throws Exception
      */
     protected function guardAgainstEmpty(
         $data,
-        $dataName = 'Argument',
-        $exceptionClass = InvalidArgumentException::class
+        string $dataName = 'Argument',
+        string $exceptionClass = InvalidArgumentException::class
     ) {
         if (empty($data)) {
             $message = sprintf('%s cannot be empty', $dataName);

--- a/src/Guard/NullGuardTrait.php
+++ b/src/Guard/NullGuardTrait.php
@@ -18,15 +18,13 @@ trait NullGuardTrait
      * Verify that the data is not null
      *
      * @param mixed  $data           the data to verify
-     * @param string $dataName       the data name
-     * @param string $exceptionClass FQCN for the exception
      * @return void
      * @throws Exception
      */
     protected function guardAgainstNull(
         $data,
-        $dataName = 'Argument',
-        $exceptionClass = InvalidArgumentException::class
+        string $dataName = 'Argument',
+        string $exceptionClass = InvalidArgumentException::class
     ) {
         if (null === $data) {
             $message = sprintf('%s cannot be null', $dataName);

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -64,10 +64,9 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Priority defaults to 1 (low priority) if none provided.
      *
      * @param  mixed $data
-     * @param  int $priority
      * @return PriorityQueue
      */
-    public function insert($data, $priority = 1)
+    public function insert($data, int $priority = 1)
     {
         $priority      = (int) $priority;
         $this->items[] = [
@@ -266,10 +265,9 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * sorted). You may provide one of the EXTR_* flags as an argument, allowing
      * the ability to return priorities or both data and priority.
      *
-     * @param  int $flag
      * @return array
      */
-    public function toArray($flag = self::EXTR_DATA)
+    public function toArray(int $flag = self::EXTR_DATA)
     {
         switch ($flag) {
             case self::EXTR_BOTH:
@@ -292,12 +290,11 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Please see {@link getIterator()} for details on the necessity of an
      * internal queue class. The class provided should extend SplPriorityQueue.
      *
-     * @param  string $class
      * @return PriorityQueue
      */
-    public function setInternalQueueClass($class)
+    public function setInternalQueueClass(string $class)
     {
-        $this->queueClass = (string) $class;
+        $this->queueClass = $class;
         return $this;
     }
 
@@ -320,10 +317,9 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     /**
      * Does the queue have an item with the given priority?
      *
-     * @param  int $priority
      * @return bool
      */
-    public function hasPriority($priority)
+    public function hasPriority(int $priority)
     {
         foreach ($this->items as $item) {
             if ($item['priority'] === $priority) {

--- a/src/StringWrapper/AbstractStringWrapper.php
+++ b/src/StringWrapper/AbstractStringWrapper.php
@@ -39,11 +39,9 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
      * Check if the given character encoding is supported by this wrapper
      * and the character encoding to convert to is also supported.
      *
-     * @param  string      $encoding
-     * @param  string|null $convertEncoding
      * @return bool
      */
-    public static function isSupported($encoding, $convertEncoding = null)
+    public static function isSupported(string $encoding, ?string $convertEncoding = null)
     {
         $supportedEncodings = static::getSupportedEncodings();
 
@@ -61,11 +59,9 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
     /**
      * Set character encoding working with and convert to
      *
-     * @param string      $encoding         The character encoding to work with
-     * @param string|null $convertEncoding  The character encoding to convert to
      * @return StringWrapperInterface
      */
-    public function setEncoding($encoding, $convertEncoding = null)
+    public function setEncoding(string $encoding, ?string $convertEncoding = null)
     {
         $supportedEncodings = static::getSupportedEncodings();
 
@@ -117,11 +113,9 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
     /**
      * Convert a string from defined character encoding to the defined convert encoding
      *
-     * @param string  $str
-     * @param bool $reverse
      * @return string|false
      */
-    public function convert($str, $reverse = false)
+    public function convert(string $str, bool $reverse = false)
     {
         $encoding        = $this->getEncoding();
         $convertEncoding = $this->getConvertEncoding();
@@ -147,25 +141,18 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
     /**
      * Wraps a string to a given number of characters
      *
-     * @param  string  $string
-     * @param  int $width
-     * @param  string  $break
-     * @param  bool $cut
      * @return string|false
      */
-    public function wordWrap($string, $width = 75, $break = "\n", $cut = false)
+    public function wordWrap(string $string, int $width = 75, string $break = "\n", bool $cut = false)
     {
-        $string = (string) $string;
         if ($string === '') {
             return '';
         }
 
-        $break = (string) $break;
         if ($break === '') {
             throw new Exception\InvalidArgumentException('Break string cannot be empty');
         }
 
-        $width = (int) $width;
         if ($width === 0 && $cut) {
             throw new Exception\InvalidArgumentException('Cannot force cut when width is zero');
         }
@@ -228,13 +215,9 @@ abstract class AbstractStringWrapper implements StringWrapperInterface
     /**
      * Pad a string to a certain length with another string
      *
-     * @param  string  $input
-     * @param  int $padLength
-     * @param  string  $padString
-     * @param  int $padType
      * @return string
      */
-    public function strPad($input, $padLength, $padString = ' ', $padType = STR_PAD_RIGHT)
+    public function strPad(string $input, int $padLength, string $padString = ' ', int $padType = STR_PAD_RIGHT)
     {
         if (null === $this->getEncoding() || StringUtils::isSingleByteEncoding($this->getEncoding())) {
             return str_pad($input, $padLength, $padString, $padType);

--- a/src/StringWrapper/Iconv.php
+++ b/src/StringWrapper/Iconv.php
@@ -226,10 +226,9 @@ class Iconv extends AbstractStringWrapper
     /**
      * Returns the length of the given string
      *
-     * @param string $str
      * @return int|false
      */
-    public function strlen($str)
+    public function strlen(string $str)
     {
         return iconv_strlen($str, $this->getEncoding());
     }
@@ -237,12 +236,9 @@ class Iconv extends AbstractStringWrapper
     /**
      * Returns the portion of string specified by the start and length parameters
      *
-     * @param string   $str
-     * @param int      $offset
-     * @param int|null $length
      * @return string|false
      */
-    public function substr($str, $offset = 0, $length = null)
+    public function substr(string $str, int $offset = 0, ?int $length = null)
     {
         return iconv_substr($str, $offset, $length, $this->getEncoding());
     }
@@ -250,12 +246,9 @@ class Iconv extends AbstractStringWrapper
     /**
      * Find the position of the first occurrence of a substring in a string
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $offset
      * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = 0)
+    public function strpos(string $haystack, string $needle, int $offset = 0)
     {
         return iconv_strpos($haystack, $needle, $offset, $this->getEncoding());
     }
@@ -263,11 +256,9 @@ class Iconv extends AbstractStringWrapper
     /**
      * Convert a string from defined encoding to the defined convert encoding
      *
-     * @param string  $str
-     * @param bool $reverse
      * @return string|false
      */
-    public function convert($str, $reverse = false)
+    public function convert(string $str, bool $reverse = false)
     {
         $encoding        = $this->getEncoding();
         $convertEncoding = $this->getConvertEncoding();

--- a/src/StringWrapper/Intl.php
+++ b/src/StringWrapper/Intl.php
@@ -47,10 +47,9 @@ class Intl extends AbstractStringWrapper
     /**
      * Returns the length of the given string
      *
-     * @param string $str
      * @return false|int
      */
-    public function strlen($str)
+    public function strlen(string $str)
     {
         $len = grapheme_strlen($str);
         return $len ?? false;
@@ -59,12 +58,9 @@ class Intl extends AbstractStringWrapper
     /**
      * Returns the portion of string specified by the start and length parameters
      *
-     * @param string   $str
-     * @param int      $offset
-     * @param int|null $length
      * @return string|false
      */
-    public function substr($str, $offset = 0, $length = null)
+    public function substr(string $str, int $offset = 0, ?int $length = null)
     {
         // Due fix of PHP #62759 The third argument returns an empty string if is 0 or null.
         if ($length !== null) {
@@ -77,12 +73,9 @@ class Intl extends AbstractStringWrapper
     /**
      * Find the position of the first occurrence of a substring in a string
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $offset
      * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = 0)
+    public function strpos(string $haystack, string $needle, int $offset = 0)
     {
         return grapheme_strpos($haystack, $needle, $offset);
     }

--- a/src/StringWrapper/MbString.php
+++ b/src/StringWrapper/MbString.php
@@ -63,10 +63,9 @@ class MbString extends AbstractStringWrapper
     /**
      * Returns the length of the given string
      *
-     * @param string $str
      * @return int|false
      */
-    public function strlen($str)
+    public function strlen(string $str)
     {
         return mb_strlen($str, $this->getEncoding());
     }
@@ -74,12 +73,9 @@ class MbString extends AbstractStringWrapper
     /**
      * Returns the portion of string specified by the start and length parameters
      *
-     * @param string   $str
-     * @param int      $offset
-     * @param int|null $length
      * @return string|false
      */
-    public function substr($str, $offset = 0, $length = null)
+    public function substr(string $str, int $offset = 0, ?int $length = null)
     {
         return mb_substr($str, $offset, $length, $this->getEncoding());
     }
@@ -87,12 +83,9 @@ class MbString extends AbstractStringWrapper
     /**
      * Find the position of the first occurrence of a substring in a string
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $offset
      * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = 0)
+    public function strpos(string $haystack, string $needle, int $offset = 0)
     {
         return mb_strpos($haystack, $needle, $offset, $this->getEncoding());
     }
@@ -100,11 +93,9 @@ class MbString extends AbstractStringWrapper
     /**
      * Convert a string from defined encoding to the defined convert encoding
      *
-     * @param string  $str
-     * @param bool $reverse
      * @return string|false
      */
-    public function convert($str, $reverse = false)
+    public function convert(string $str, bool $reverse = false)
     {
         $encoding        = $this->getEncoding();
         $convertEncoding = $this->getConvertEncoding();

--- a/src/StringWrapper/Native.php
+++ b/src/StringWrapper/Native.php
@@ -27,11 +27,9 @@ class Native extends AbstractStringWrapper
      * Check if the given character encoding is supported by this wrapper
      * and the character encoding to convert to is also supported.
      *
-     * @param  string      $encoding
-     * @param  string|null $convertEncoding
      * @return bool
      */
-    public static function isSupported($encoding, $convertEncoding = null)
+    public static function isSupported(string $encoding, ?string $convertEncoding = null)
     {
         $encodingUpper      = strtoupper($encoding);
         $supportedEncodings = static::getSupportedEncodings();
@@ -61,11 +59,9 @@ class Native extends AbstractStringWrapper
     /**
      * Set character encoding working with and convert to
      *
-     * @param string      $encoding         The character encoding to work with
-     * @param string|null $convertEncoding  The character encoding to convert to
      * @return StringWrapperInterface
      */
-    public function setEncoding($encoding, $convertEncoding = null)
+    public function setEncoding(string $encoding, ?string $convertEncoding = null)
     {
         $supportedEncodings = static::getSupportedEncodings();
 
@@ -99,10 +95,9 @@ class Native extends AbstractStringWrapper
     /**
      * Returns the length of the given string
      *
-     * @param string $str
      * @return int|false
      */
-    public function strlen($str)
+    public function strlen(string $str)
     {
         return strlen($str);
     }
@@ -110,12 +105,9 @@ class Native extends AbstractStringWrapper
     /**
      * Returns the portion of string specified by the start and length parameters
      *
-     * @param string   $str
-     * @param int      $offset
-     * @param int|null $length
      * @return string|false
      */
-    public function substr($str, $offset = 0, $length = null)
+    public function substr(string $str, int $offset = 0, ?int $length = null)
     {
         return substr($str, $offset, $length);
     }
@@ -123,12 +115,9 @@ class Native extends AbstractStringWrapper
     /**
      * Find the position of the first occurrence of a substring in a string
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $offset
      * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = 0)
+    public function strpos(string $haystack, string $needle, int $offset = 0)
     {
         return strpos($haystack, $needle, $offset);
     }

--- a/src/StringWrapper/StringWrapperInterface.php
+++ b/src/StringWrapper/StringWrapperInterface.php
@@ -11,11 +11,8 @@ interface StringWrapperInterface
     /**
      * Check if the given character encoding is supported by this wrapper
      * and the character encoding to convert to is also supported.
-     *
-     * @param string      $encoding
-     * @param string|null $convertEncoding
      */
-    public static function isSupported($encoding, $convertEncoding = null);
+    public static function isSupported(string $encoding, ?string $convertEncoding = null);
 
     /**
      * Get a list of supported character encodings
@@ -27,11 +24,9 @@ interface StringWrapperInterface
     /**
      * Set character encoding working with and convert to
      *
-     * @param string      $encoding         The character encoding to work with
-     * @param string|null $convertEncoding  The character encoding to convert to
      * @return StringWrapperInterface
      */
-    public function setEncoding($encoding, $convertEncoding = null);
+    public function setEncoding(string $encoding, ?string $convertEncoding = null);
 
     /**
      * Get the defined character encoding to work with (upper case)
@@ -50,59 +45,42 @@ interface StringWrapperInterface
     /**
      * Returns the length of the given string
      *
-     * @param string $str
      * @return int|false
      */
-    public function strlen($str);
+    public function strlen(string $str);
 
     /**
      * Returns the portion of string specified by the start and length parameters
      *
-     * @param string   $str
-     * @param int      $offset
-     * @param int|null $length
      * @return string|false
      */
-    public function substr($str, $offset = 0, $length = null);
+    public function substr(string $str, int $offset = 0, ?int $length = null);
 
     /**
      * Find the position of the first occurrence of a substring in a string
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int    $offset
      * @return int|false
      */
-    public function strpos($haystack, $needle, $offset = 0);
+    public function strpos(string $haystack, string $needle, int $offset = 0);
 
     /**
      * Convert a string from defined encoding to the defined convert encoding
      *
-     * @param string  $str
-     * @param bool $reverse
      * @return string|false
      */
-    public function convert($str, $reverse = false);
+    public function convert(string $str, bool $reverse = false);
 
     /**
      * Wraps a string to a given number of characters
      *
-     * @param  string  $str
-     * @param  int $width
-     * @param  string  $break
-     * @param  bool $cut
      * @return string
      */
-    public function wordWrap($str, $width = 75, $break = "\n", $cut = false);
+    public function wordWrap(string $str, int $width = 75, string $break = "\n", bool $cut = false);
 
     /**
      * Pad a string to a certain length with another string
      *
-     * @param  string  $input
-     * @param  int $padLength
-     * @param  string  $padString
-     * @param  int $padType
      * @return string
      */
-    public function strPad($input, $padLength, $padString = ' ', $padType = STR_PAD_RIGHT);
+    public function strPad(string $input, int $padLength, string $padString = ' ', int $padType = STR_PAD_RIGHT);
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Similar PR to: https://github.com/laminas/laminas-escaper/pull/23/files I started with the string wrapper namespace as an issue was raised against it. 

~~Progressively adding more classes to this PR as time permits~~ I've added typehints to every class where it seems sensible to do so, there are some which inherit/implement built-ins which don't declare the type hint and so opens up a bit of an issue to then add them, you may wish to merge some parts and not others so splitting allows for easier cherry-picking. 

Only typehints which don't break bc have been added; eg ones which PHP will silently cast to when strict types = 0; notably callable type hints have not been added and some instances of iterable have been skipped where the previous behaviour was to throw an exception if it wasn't an iterable.  
