### PR TITLE
Removed `laminas/laminas-zendframework-bridge`, removed `zendframework/zend-stdlib` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ^8.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",
@@ -53,7 +52,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-stdlib": "^3.2.1"
+    "conflict": {
+        "zendframework/zend-stdlib": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,71 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "229399b545f97604de653671a531ca7b",
-    "packages": [
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
-                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-06-24T12:49:22+00:00"
-        }
-    ],
+    "content-hash": "3c48dbd77ba585b9eb9dea84515ac2e1",
+    "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
@@ -5175,5 +5112,5 @@
         "php": "^7.3 || ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

This patch is an initial probe to validate the approach discussed during the 2021-08-02 TSC meeting
at https://github.com/laminas/technical-steering-committee/blob/ecdb4542b7f553905c1a9597c7b589d9a80357ce/meetings/agenda.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages

See https://github.com/laminas/technical-steering-committee/pull/90

In practice, we:

 * remove `laminas/laminas-zendframework-bridge` (which has a performance impact)
 * reduce dependencies (through the above)
 * explicitly declare an incompatibility between `laminas/laminas-stdlib` and `zendframework/zend-stdlib`,
   preventing installation until downstream consumers removed `zendframework/zend-stdlib` from their
   direct or transitive dependencies
 * removed the declaration that made this library a `1:1` replacement of `laminas/laminas-stdlib`

By doing so, it is possible for us to drop `laminas/laminas-zendframework-bridge` in the next minor release
of this library (`3.5.0`).
