### PR TITLE
Provide PHP 8.1 compatibility

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,17 @@
         "vimeo/psalm": "^4.7"
     },
     "autoload": {
+        "files": [
+            "src/autoload.php"
+        ],
         "psr-4": {
             "Laminas\\Stdlib\\": "src/"
         }
     },
     "autoload-dev": {
+        "files": [
+            "test/autoload.php"
+        ],
         "psr-4": {
             "LaminasTest\\Stdlib\\": "test/",
             "LaminasBench\\Stdlib\\": "benchmark/"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e87e10e9a23ed70f23a4c921ba44f69",
+    "content-hash": "0ca66a7411f00dee3f24f2b162870c72",
     "packages": [],
     "packages-dev": [
         {
@@ -5109,7 +5109,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -2358,20 +2358,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -2391,7 +2391,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -2401,9 +2401,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",
@@ -2455,30 +2455,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2499,9 +2499,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -2358,20 +2358,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "3.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
@@ -2391,7 +2391,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -2401,9 +2401,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+                "source": "https://github.com/php-fig/cache/tree/master"
             },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/container",
@@ -2455,30 +2455,30 @@
         },
         {
             "name": "psr/log",
-            "version": "2.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2499,9 +2499,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/2.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:41:46+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,4 +18,9 @@
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>
+
+    <!-- Exclude the following until PHP 8 is our minimum version -->
+    <exclude-pattern>*/src/ArrayObject/PHP81Implementation.php</exclude-pattern>
+    <exclude-pattern>*/src/SplQueue/PHP81Implementation.php</exclude-pattern>
+    <exclude-pattern>*/src/SplStack/PHP81Implementation.php</exclude-pattern>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+<files psalm-version="4.9.3@4c262932602b9bbab5020863d1eb22d49de0dbf4">
   <file src="src/AbstractOptions.php">
     <DocblockTypeContradiction occurrences="1">
       <code>! is_array($options) &amp;&amp; ! $options instanceof Traversable</code>
@@ -21,49 +21,17 @@
       <code>$this</code>
     </RawObjectIteration>
   </file>
-  <file src="src/ArrayObject.php">
+  <file src="src/ArrayObject/LegacyImplementation.php">
     <DocblockTypeContradiction occurrences="1">
       <code>! is_array($data) &amp;&amp; ! is_object($data)</code>
     </DocblockTypeContradiction>
     <InvalidStringClass occurrences="1">
       <code>new $class($this-&gt;storage)</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>new $class($this-&gt;storage)</code>
-    </LessSpecificReturnStatement>
-    <MixedArgument occurrences="6">
-      <code>$ar['flag']</code>
-      <code>$ar['iteratorClass']</code>
-      <code>$ar['storage']</code>
-      <code>$v</code>
-      <code>$v</code>
-      <code>$v</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$function</code>
-      <code>$function</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$ar['flag']</code>
-      <code>$ar['iteratorClass']</code>
-      <code>$ar['storage']</code>
-    </MixedArrayAccess>
-    <MixedArrayOffset occurrences="4">
-      <code>$this-&gt;storage[$key]</code>
-      <code>$this-&gt;storage[$key]</code>
-      <code>$this-&gt;storage[$key]</code>
-      <code>$this-&gt;storage[$key]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
-      <code>$ar</code>
-      <code>$k</code>
+    <MixedAssignment occurrences="2">
       <code>$ret</code>
       <code>$ret</code>
-      <code>$v</code>
     </MixedAssignment>
-    <MoreSpecificReturnType occurrences="1">
-      <code>Iterator</code>
-    </MoreSpecificReturnType>
     <PossiblyInvalidPropertyAssignmentValue occurrences="1">
       <code>$input</code>
     </PossiblyInvalidPropertyAssignmentValue>
@@ -74,6 +42,32 @@
       <code>is_callable($function)</code>
       <code>is_callable($function)</code>
     </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/ArrayObject/PHP81Implementation.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>! is_array($data) &amp;&amp; ! is_object($data)</code>
+    </DocblockTypeContradiction>
+    <InvalidStringClass occurrences="1">
+      <code>new $class($this-&gt;storage)</code>
+    </InvalidStringClass>
+    <MixedAssignment occurrences="2">
+      <code>$ret</code>
+      <code>$ret</code>
+    </MixedAssignment>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$input</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$iteratorClass</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>is_callable($function)</code>
+      <code>is_callable($function)</code>
+    </RedundantConditionGivenDocblockType>
+    <ReservedWord occurrences="2">
+      <code>mixed</code>
+      <code>mixed</code>
+    </ReservedWord>
   </file>
   <file src="src/ArrayUtils.php">
     <DocblockTypeContradiction occurrences="1">
@@ -124,56 +118,36 @@
       <code>$errorException</code>
     </MixedReturnStatement>
   </file>
-  <file src="src/FastPriorityQueue.php">
+  <file src="src/FastPriorityQueue/LegacyImplementation.php">
     <DocblockTypeContradiction occurrences="1">
       <code>is_int($priority)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="11">
-      <code>$item['priority']</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority]</code>
-      <code>$values</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$item['data']</code>
-      <code>$item['priority']</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority][$index]</code>
-      <code>$this-&gt;values[$this-&gt;maxPriority][$key]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;values[$priority][]</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="4">
       <code>$array[]</code>
-      <code>$data[]</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$item</code>
-      <code>$this-&gt;maxPriority</code>
-      <code>$this-&gt;maxPriority</code>
-      <code>$this-&gt;maxPriority</code>
-      <code>$this-&gt;maxPriority</code>
       <code>$value</code>
-      <code>$values</code>
     </MixedAssignment>
-    <PossiblyNullArrayOffset occurrences="9">
-      <code>$this-&gt;priorities</code>
-      <code>$this-&gt;priorities</code>
-      <code>$this-&gt;subPriorities</code>
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-    </PossiblyNullArrayOffset>
+    <RedundantCast occurrences="1">
+      <code>(int) $priority</code>
+    </RedundantCast>
+  </file>
+  <file src="src/FastPriorityQueue/PHP81Implementation.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_int($priority)</code>
+    </DocblockTypeContradiction>
+    <MixedAssignment occurrences="4">
+      <code>$array[]</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <RedundantCast occurrences="1">
+      <code>(int) $priority</code>
+    </RedundantCast>
+    <ReservedWord occurrences="1">
+      <code>mixed</code>
+    </ReservedWord>
   </file>
   <file src="src/Glob.php">
     <InvalidOperand occurrences="2">
@@ -217,21 +191,20 @@
       <code>setMetadata</code>
     </MissingReturnType>
   </file>
-  <file src="src/Parameters.php">
+  <file src="src/Parameters/LegacyImplementation.php">
     <MixedAssignment occurrences="1">
       <code>$this[$name]</code>
     </MixedAssignment>
   </file>
-  <file src="src/PriorityList.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$node ? $node['data'] : false</code>
-    </InvalidReturnStatement>
-    <MissingClosureReturnType occurrences="1">
-      <code>function ($item) use ($flag) {</code>
-    </MissingClosureReturnType>
-    <MixedInferredReturnType occurrences="1">
-      <code>next</code>
-    </MixedInferredReturnType>
+  <file src="src/Parameters/PHP81Implementation.php">
+    <MixedAssignment occurrences="1">
+      <code>$this[$name]</code>
+    </MixedAssignment>
+    <ReservedWord occurrences="1">
+      <code>mixed</code>
+    </ReservedWord>
+  </file>
+  <file src="src/PriorityList/LegacyImplementation.php">
     <MixedReturnStatement occurrences="1">
       <code>$node ? $node['data'] : false</code>
     </MixedReturnStatement>
@@ -240,74 +213,50 @@
       <code>(int) $priority</code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/PriorityQueue.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;queue</code>
+  <file src="src/PriorityList/PHP81Implementation.php">
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(int) $priority</code>
+      <code>(int) $priority</code>
+    </RedundantCastGivenDocblockType>
+    <ReservedWord occurrences="3">
+      <code>mixed</code>
+      <code>mixed</code>
+      <code>mixed</code>
+    </ReservedWord>
+  </file>
+  <file src="src/PriorityQueue/LegacyImplementation.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! is_array($item)</code>
+      <code>! is_array($item)</code>
     </DocblockTypeContradiction>
     <InvalidStringClass occurrences="1">
       <code>new $this-&gt;queueClass()</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;queue</code>
-    </LessSpecificReturnStatement>
-    <MissingClosureReturnType occurrences="2">
-      <code>function ($item) {</code>
-      <code>function ($item) {</code>
-    </MissingClosureReturnType>
-    <MissingConstructor occurrences="1">
-      <code>$queue</code>
-    </MissingConstructor>
-    <MixedArgument occurrences="1">
-      <code>$item['priority']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="13">
-      <code>$item['data']</code>
-      <code>$item['data']</code>
-      <code>$item['data']</code>
-      <code>$item['data']</code>
-      <code>$item['data']</code>
-      <code>$item['data']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-      <code>$item['priority']</code>
-    </MixedArrayAccess>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;items[$key]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="9">
-      <code>$highestPriority</code>
-      <code>$highestPriority</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
+    <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <MoreSpecificReturnType occurrences="1">
-      <code>SplPriorityQueue</code>
-    </MoreSpecificReturnType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUndefinedVariable occurrences="1">
-      <code>$key</code>
-    </PossiblyUndefinedVariable>
-    <PropertyTypeCoercion occurrences="1">
-      <code>new $this-&gt;queueClass()</code>
-    </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType occurrences="3">
+      <code>(int) $item['priority']</code>
       <code>(int) $priority</code>
       <code>(string) $class</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>null !== $this-&gt;queue</code>
-    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/PriorityQueue/PHP81Implementation.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! is_array($item)</code>
+      <code>! is_array($item)</code>
+    </DocblockTypeContradiction>
+    <InvalidStringClass occurrences="1">
+      <code>new $this-&gt;queueClass()</code>
+    </InvalidStringClass>
+    <MixedAssignment occurrences="1">
+      <code>$value</code>
+    </MixedAssignment>
+    <RedundantCastGivenDocblockType occurrences="3">
+      <code>(int) $item['priority']</code>
+      <code>(int) $priority</code>
+      <code>(string) $class</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/SplPriorityQueue.php">
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -316,29 +265,32 @@
     <MethodSignatureMismatch occurrences="1">
       <code>public function insert($datum, $priority)</code>
     </MethodSignatureMismatch>
-    <MixedArrayAccess occurrences="2">
-      <code>$item['data']</code>
-      <code>$item['priority']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="2">
       <code>$array[]</code>
-      <code>$data[]</code>
-      <code>$item</code>
-      <code>$item</code>
       <code>$item</code>
     </MixedAssignment>
   </file>
-  <file src="src/SplQueue.php">
-    <MixedAssignment occurrences="3">
+  <file src="src/SplQueue/LegacyImplementation.php">
+    <MixedAssignment occurrences="2">
       <code>$array[]</code>
-      <code>$item</code>
       <code>$item</code>
     </MixedAssignment>
   </file>
-  <file src="src/SplStack.php">
-    <MixedAssignment occurrences="3">
+  <file src="src/SplQueue/PHP81Implementation.php">
+    <MixedAssignment occurrences="2">
       <code>$array[]</code>
       <code>$item</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/SplStack/LegacyImplementation.php">
+    <MixedAssignment occurrences="2">
+      <code>$array[]</code>
+      <code>$item</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/SplStack/PHP81Implementation.php">
+    <MixedAssignment occurrences="2">
+      <code>$array[]</code>
       <code>$item</code>
     </MixedAssignment>
   </file>

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -455,12 +455,12 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
     }
 
-   /**
+    /**
      * Magic method used to rebuild an instance.
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         $this->protectedProperties = array_keys(get_object_vars($this));

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -349,6 +349,16 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
      * Sets the behavior flags
      *
      * @param  int  $flags
@@ -444,4 +454,37 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
             }
         }
     }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        $this->protectedProperties = array_keys(get_object_vars($this));
+
+        $this->setFlags($data['flag']);
+        $this->exchangeArray($data['storage']);
+        $this->setIteratorClass($data['iteratorClass']);
+
+        foreach ($data as $k => $v) {
+            switch ($k) {
+                case 'flag':
+                    $this->setFlags($v);
+                    break;
+                case 'storage':
+                    $this->exchangeArray($v);
+                    break;
+                case 'iteratorClass':
+                    $this->setIteratorClass($v);
+                    break;
+                case 'protectedProperties':
+                    break;
+                default:
+                    $this->__set($k, $v);
+            }
+        }
+    }	
 }

--- a/src/ArrayObject/LegacyImplementation.php
+++ b/src/ArrayObject/LegacyImplementation.php
@@ -7,10 +7,10 @@ namespace Laminas\Stdlib\ArrayObject;
 use ArrayAccess;
 use ArrayObject;
 use Countable;
+use Iterator;
 use IteratorAggregate;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Serializable;
-use Traversable;
 use UnexpectedValueException;
 
 use function array_keys;
@@ -243,14 +243,14 @@ class LegacyImplementation implements IteratorAggregate, ArrayAccess, Serializab
     /**
      * Create a new iterator from an ArrayObject instance
      *
-     * @return Traversable
+     * @return Iterator
      */
     public function getIterator()
     {
         $class    = $this->iteratorClass;
         $iterator = new $class($this->storage);
 
-        if (! $iterator instanceof Traversable) {
+        if (! $iterator instanceof Iterator) {
             throw new UnexpectedValueException(sprintf(
                 'Iterator of type %s is not Traversable',
                 $class

--- a/src/ArrayObject/LegacyImplementation.php
+++ b/src/ArrayObject/LegacyImplementation.php
@@ -1,0 +1,513 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\ArrayObject;
+
+use ArrayAccess;
+use ArrayObject;
+use Countable;
+use Iterator;
+use IteratorAggregate;
+use Laminas\Stdlib\Exception\InvalidArgumentException;
+use Serializable;
+use UnexpectedValueException;
+
+use function array_keys;
+use function asort;
+use function class_exists;
+use function count;
+use function get_class;
+use function get_object_vars;
+use function gettype;
+use function in_array;
+use function is_array;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function ksort;
+use function natcasesort;
+use function natsort;
+use function serialize;
+use function sprintf;
+use function strpos;
+use function uasort;
+use function uksort;
+use function unserialize;
+
+/**
+ * Custom framework ArrayObject implementation
+ *
+ * Extends version-specific "abstract" implementation.
+ */
+class LegacyImplementation implements IteratorAggregate, ArrayAccess, Serializable, Countable
+{
+    /**
+     * Properties of the object have their normal functionality
+     * when accessed as list (var_dump, foreach, etc.).
+     */
+    public const STD_PROP_LIST = 1;
+
+    /**
+     * Entries can be accessed as properties (read and write).
+     */
+    public const ARRAY_AS_PROPS = 2;
+
+    /** @var array */
+    protected $storage;
+
+    /** @var int */
+    protected $flag;
+
+    /** @var string */
+    protected $iteratorClass;
+
+    /** @var array */
+    protected $protectedProperties;
+
+    /**
+     * Constructor
+     *
+     * @param array|object $input Object values must act like ArrayAccess
+     * @param int          $flags
+     * @param string       $iteratorClass
+     */
+    public function __construct($input = [], $flags = self::STD_PROP_LIST, $iteratorClass = 'ArrayIterator')
+    {
+        $this->setFlags($flags);
+        $this->storage = $input;
+        $this->setIteratorClass($iteratorClass);
+        $this->protectedProperties = array_keys(get_object_vars($this));
+    }
+
+    /**
+     * Returns whether the requested key exists
+     *
+     * @param  mixed $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        if ($this->flag === self::ARRAY_AS_PROPS) {
+            return $this->offsetExists($key);
+        }
+
+        if (in_array($key, $this->protectedProperties)) {
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
+        }
+
+        return isset($this->$key);
+    }
+
+    /**
+     * Sets the value at the specified key to value
+     *
+     * @param  mixed $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        if ($this->flag === self::ARRAY_AS_PROPS) {
+            $this->offsetSet($key, $value);
+            return;
+        }
+
+        if (in_array($key, $this->protectedProperties)) {
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
+        }
+
+        $this->$key = $value;
+    }
+
+    /**
+     * Unsets the value at the specified key
+     *
+     * @param  mixed $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        if ($this->flag === self::ARRAY_AS_PROPS) {
+            $this->offsetUnset($key);
+            return;
+        }
+
+        if (in_array($key, $this->protectedProperties)) {
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
+        }
+
+        unset($this->$key);
+    }
+
+    /**
+     * Returns the value at the specified key by reference
+     *
+     * @param  mixed $key
+     * @return mixed
+     */
+    public function &__get($key)
+    {
+        if ($this->flag === self::ARRAY_AS_PROPS) {
+            $ret = &$this->offsetGet($key);
+
+            return $ret;
+        }
+
+        if (in_array($key, $this->protectedProperties, true)) {
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
+        }
+
+        return $this->$key;
+    }
+
+    /**
+     * Appends the value
+     *
+     * @param  mixed $value
+     * @return void
+     */
+    public function append($value)
+    {
+        $this->storage[] = $value;
+    }
+
+    /**
+     * Sort the entries by value
+     *
+     * @return void
+     */
+    public function asort()
+    {
+        asort($this->storage);
+    }
+
+    /**
+     * Get the number of public properties in the ArrayObject
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->storage);
+    }
+
+    /**
+     * Exchange the array for another one.
+     *
+     * @param  array|ArrayObject|ArrayIterator|object $data
+     * @return array
+     */
+    public function exchangeArray($data)
+    {
+        if (! is_array($data) && ! is_object($data)) {
+            throw new InvalidArgumentException(
+                'Passed variable is not an array or object, using empty array instead'
+            );
+        }
+
+        if (is_object($data) && ($data instanceof self || $data instanceof ArrayObject)) {
+            $data = $data->getArrayCopy();
+        }
+        if (! is_array($data)) {
+            $data = (array) $data;
+        }
+
+        $storage = $this->storage;
+
+        $this->storage = $data;
+
+        return $storage;
+    }
+
+    /**
+     * Creates a copy of the ArrayObject.
+     *
+     * @return array
+     */
+    public function getArrayCopy()
+    {
+        return $this->storage;
+    }
+
+    /**
+     * Gets the behavior flags.
+     *
+     * @return int
+     */
+    public function getFlags()
+    {
+        return $this->flag;
+    }
+
+    /**
+     * Create a new iterator from an ArrayObject instance
+     *
+     * @return Iterator
+     */
+    public function getIterator()
+    {
+        $class = $this->iteratorClass;
+
+        return new $class($this->storage);
+    }
+
+    /**
+     * Gets the iterator classname for the ArrayObject.
+     *
+     * @return string
+     */
+    public function getIteratorClass()
+    {
+        return $this->iteratorClass;
+    }
+
+    /**
+     * Sort the entries by key
+     *
+     * @return void
+     */
+    public function ksort()
+    {
+        ksort($this->storage);
+    }
+
+    /**
+     * Sort an array using a case insensitive "natural order" algorithm
+     *
+     * @return void
+     */
+    public function natcasesort()
+    {
+        natcasesort($this->storage);
+    }
+
+    /**
+     * Sort entries using a "natural order" algorithm
+     *
+     * @return void
+     */
+    public function natsort()
+    {
+        natsort($this->storage);
+    }
+
+    /**
+     * Returns whether the requested key exists
+     *
+     * @param  mixed $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return isset($this->storage[$key]);
+    }
+
+    /**
+     * Returns the value at the specified key
+     *
+     * @param  mixed $key
+     * @return mixed
+     */
+    public function &offsetGet($key)
+    {
+        $ret = null;
+        if (! $this->offsetExists($key)) {
+            return $ret;
+        }
+        $ret = &$this->storage[$key];
+
+        return $ret;
+    }
+
+    /**
+     * Sets the value at the specified key to value
+     *
+     * @param  mixed $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->storage[$key] = $value;
+    }
+
+    /**
+     * Unsets the value at the specified key
+     *
+     * @param  mixed $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        if ($this->offsetExists($key)) {
+            unset($this->storage[$key]);
+        }
+    }
+
+    /**
+     * Serialize an ArrayObject
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize(get_object_vars($this));
+    }
+
+    /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * Sets the behavior flags
+     *
+     * @param  int  $flags
+     * @return void
+     */
+    public function setFlags($flags)
+    {
+        $this->flag = $flags;
+    }
+
+    /**
+     * Sets the iterator classname for the ArrayObject
+     *
+     * @param  string $class
+     * @return void
+     */
+    public function setIteratorClass($class)
+    {
+        if (class_exists($class)) {
+            $this->iteratorClass = $class;
+
+            return;
+        }
+
+        if (strpos($class, '\\') === 0) {
+            $class = '\\' . $class;
+            if (class_exists($class)) {
+                $this->iteratorClass = $class;
+
+                return;
+            }
+        }
+
+        throw new InvalidArgumentException('The iterator class does not exist');
+    }
+
+    /**
+     * Sort the entries with a user-defined comparison function and maintain key association
+     *
+     * @param  callable $function
+     * @return void
+     */
+    public function uasort($function)
+    {
+        if (is_callable($function)) {
+            uasort($this->storage, $function);
+        }
+    }
+
+    /**
+     * Sort the entries by keys using a user-defined comparison function
+     *
+     * @param  callable $function
+     * @return void
+     */
+    public function uksort($function)
+    {
+        if (is_callable($function)) {
+            uksort($this->storage, $function);
+        }
+    }
+
+    /**
+     * Unserialize an ArrayObject
+     *
+     * @param  string $data
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        $ar                        = unserialize($data);
+        $this->protectedProperties = array_keys(get_object_vars($this));
+
+        $this->setFlags($ar['flag']);
+        $this->exchangeArray($ar['storage']);
+        $this->setIteratorClass($ar['iteratorClass']);
+
+        foreach ($ar as $k => $v) {
+            switch ($k) {
+                case 'flag':
+                    $this->setFlags($v);
+                    break;
+                case 'storage':
+                    $this->exchangeArray($v);
+                    break;
+                case 'iteratorClass':
+                    $this->setIteratorClass($v);
+                    break;
+                case 'protectedProperties':
+                    break;
+                default:
+                    $this->__set($k, $v);
+            }
+        }
+    }
+
+    /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        $this->protectedProperties = array_keys(get_object_vars($this));
+
+        foreach ($data as $k => $v) {
+            switch ($k) {
+                case 'flag':
+                    $this->setFlags((int) $v);
+                    break;
+
+                case 'storage':
+                    if (! is_array($v) && ! is_object($v)) {
+                        throw new UnexpectedValueException(sprintf(
+                            'Cannot unserialize to %s; expected "storage" value of array or object, received %s',
+                            self::class,
+                            gettype($v)
+                        ));
+                    }
+                    $this->exchangeArray($v);
+                    break;
+
+                case 'iteratorClass':
+                    if (! is_string($v)) {
+                        throw new UnexpectedValueException(sprintf(
+                            'Cannot unserialize to %s; expected "iteratorClass" value as string, received %s',
+                            self::class,
+                            is_object($v) ? get_class($v) : gettype($v)
+                        ));
+                    }
+
+                    $this->setIteratorClass($v);
+                    break;
+
+                case 'protectedProperties':
+                    break;
+
+                default:
+                    $this->__set($k, $v);
+                    break;
+            }
+        }
+    }
+}

--- a/src/ArrayObject/PHP81Implementation.php
+++ b/src/ArrayObject/PHP81Implementation.php
@@ -6,10 +6,10 @@ namespace Laminas\Stdlib\ArrayObject;
 
 use ArrayAccess;
 use Countable;
+use Iterator;
 use IteratorAggregate;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Serializable;
-use Traversable;
 use UnexpectedValueException;
 
 use function array_keys;
@@ -240,12 +240,13 @@ class PHP81Implementation implements IteratorAggregate, ArrayAccess, Serializabl
     /**
      * Create a new iterator from an ArrayObject instance
      */
-    public function getIterator(): Traversable
+    #[ReturnTypeWillChange]
+    public function getIterator(): Iterator
     {
         $class    = $this->iteratorClass;
         $iterator = new $class($this->storage);
 
-        if (! $iterator instanceof Traversable) {
+        if (! $iterator instanceof Iterator) {
             throw new UnexpectedValueException(sprintf(
                 'Iterator of type %s is not Traversable',
                 $class

--- a/src/ArrayObject/PHP81Implementation.php
+++ b/src/ArrayObject/PHP81Implementation.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\ArrayObject;
 
 use ArrayAccess;
 use Countable;
-use Iterator;
 use IteratorAggregate;
+use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Serializable;
+use Traversable;
 use UnexpectedValueException;
 
 use function array_keys;
@@ -38,7 +39,7 @@ use function unserialize;
  *
  * Extends version-specific "abstract" implementation.
  */
-class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Countable
+class PHP81Implementation implements IteratorAggregate, ArrayAccess, Serializable, Countable
 {
     /**
      * Properties of the object have their normal functionality
@@ -91,7 +92,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
         }
 
         return isset($this->$key);
@@ -112,7 +113,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
         }
 
         $this->$key = $value;
@@ -132,7 +133,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
         }
 
         unset($this->$key);
@@ -153,7 +154,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties, true)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new InvalidArgumentException('$key is a protected property, use a different key');
         }
 
         return $this->$key;
@@ -182,10 +183,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
 
     /**
      * Get the number of public properties in the ArrayObject
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->storage);
     }
@@ -199,7 +198,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     public function exchangeArray($data)
     {
         if (! is_array($data) && ! is_object($data)) {
-            throw new Exception\InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Passed variable is not an array or object, using empty array instead'
             );
         }
@@ -240,10 +239,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
 
     /**
      * Create a new iterator from an ArrayObject instance
-     *
-     * @return Iterator
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         $class = $this->iteratorClass;
 
@@ -292,54 +289,41 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
 
     /**
      * Returns whether the requested key exists
-     *
-     * @param  mixed $key
-     * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists(mixed $offset): bool
     {
-        return isset($this->storage[$key]);
+        return isset($this->storage[$offset]);
     }
 
     /**
      * Returns the value at the specified key
-     *
-     * @param  mixed $key
-     * @return mixed
      */
-    public function &offsetGet($key)
+    public function &offsetGet(mixed $offset): mixed
     {
         $ret = null;
-        if (! $this->offsetExists($key)) {
+        if (! $this->offsetExists($offset)) {
             return $ret;
         }
-        $ret = &$this->storage[$key];
+        $ret = &$this->storage[$offset];
 
         return $ret;
     }
 
     /**
      * Sets the value at the specified key to value
-     *
-     * @param  mixed $key
-     * @param  mixed $value
-     * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
-        $this->storage[$key] = $value;
+        $this->storage[$offset] = $value;
     }
 
     /**
      * Unsets the value at the specified key
-     *
-     * @param  mixed $key
-     * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset(mixed $offset): void
     {
-        if ($this->offsetExists($key)) {
-            unset($this->storage[$key]);
+        if ($this->offsetExists($offset)) {
+            unset($this->storage[$offset]);
         }
     }
 
@@ -397,7 +381,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
             }
         }
 
-        throw new Exception\InvalidArgumentException('The iterator class does not exist');
+        throw new InvalidArgumentException('The iterator class does not exist');
     }
 
     /**

--- a/src/FastPriorityQueue/LegacyImplementation.php
+++ b/src/FastPriorityQueue/LegacyImplementation.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\FastPriorityQueue;
+
+use Countable;
+use Iterator;
+use Laminas\Stdlib\Exception;
+use Serializable;
+use SplPriorityQueue as PhpSplPriorityQueue;
+
+use function current;
+use function in_array;
+use function is_int;
+use function key;
+use function max;
+use function next;
+use function reset;
+use function serialize;
+use function unserialize;
+
+/**
+ * This is an efficient implementation of an integer priority queue in PHP
+ *
+ * This class acts like a queue with insert() and extract(), removing the
+ * elements from the queue and it also acts like an Iterator without removing
+ * the elements. This behaviour can be used in mixed scenarios with high
+ * performance boost.
+ */
+class LegacyImplementation implements Iterator, Countable, Serializable
+{
+    public const EXTR_DATA     = PhpSplPriorityQueue::EXTR_DATA;
+    public const EXTR_PRIORITY = PhpSplPriorityQueue::EXTR_PRIORITY;
+    public const EXTR_BOTH     = PhpSplPriorityQueue::EXTR_BOTH;
+
+    /** @var integer */
+    protected $extractFlag = self::EXTR_DATA;
+
+    /**
+     * Elements of the queue, divided by priorities
+     *
+     * @var array
+     */
+    protected $values = [];
+
+    /**
+     * Array of priorities
+     *
+     * @var array
+     */
+    protected $priorities = [];
+
+    /**
+     * Array of priorities used for the iteration
+     *
+     * @var array
+     */
+    protected $subPriorities = [];
+
+    /**
+     * Max priority
+     *
+     * @var integer|null
+     */
+    protected $maxPriority;
+
+    /**
+     * Total number of elements in the queue
+     *
+     * @var integer
+     */
+    protected $count = 0;
+
+    /**
+     * Index of the current element in the queue
+     *
+     * @var integer
+     */
+    protected $index = 0;
+
+    /**
+     * Sub index of the current element in the same priority level
+     *
+     * @var integer
+     */
+    protected $subIndex = 0;
+
+    /**
+     * Insert an element in the queue with a specified priority
+     *
+     * @param mixed $value
+     * @param integer $priority
+     * @return void
+     */
+    public function insert($value, $priority)
+    {
+        if (! is_int($priority)) {
+            throw new Exception\InvalidArgumentException('The priority must be an integer');
+        }
+        $this->values[$priority][] = $value;
+        if (! isset($this->priorities[$priority])) {
+            $this->priorities[$priority] = $priority;
+            $this->maxPriority           = $this->maxPriority === null ? $priority : max($priority, $this->maxPriority);
+        }
+        ++$this->count;
+    }
+
+    /**
+     * Extract an element in the queue according to the priority and the
+     * order of insertion
+     *
+     * @return mixed
+     */
+    public function extract()
+    {
+        if (! $this->valid()) {
+            return false;
+        }
+        $value = $this->current();
+        $this->nextAndRemove();
+        return $value;
+    }
+
+    /**
+     * Remove an item from the queue
+     *
+     * This is different than {@link extract()}; its purpose is to dequeue an
+     * item.
+     *
+     * Note: this removes the first item matching the provided item found. If
+     * the same item has been added multiple times, it will not remove other
+     * instances.
+     *
+     * @param  mixed $datum
+     * @return bool False if the item was not found, true otherwise.
+     */
+    public function remove($datum)
+    {
+        $currentIndex    = $this->index;
+        $currentSubIndex = $this->subIndex;
+        $currentPriority = $this->maxPriority;
+
+        $this->rewind();
+        while ($this->valid()) {
+            if (current($this->values[$this->maxPriority]) === $datum) {
+                $index = key($this->values[$this->maxPriority]);
+                unset($this->values[$this->maxPriority][$index]);
+
+                // The `next()` method advances the internal array pointer, so we need to use the `reset()` function,
+                // otherwise we would lose all elements before the place the pointer points.
+                reset($this->values[$this->maxPriority]);
+
+                $this->index    = $currentIndex;
+                $this->subIndex = $currentSubIndex;
+
+                // If the array is empty we need to destroy the unnecessary priority,
+                // otherwise we would end up with an incorrect value of `$this->count`
+                // {@see \Laminas\Stdlib\FastPriorityQueue::nextAndRemove()}.
+                if (empty($this->values[$this->maxPriority])) {
+                    unset($this->values[$this->maxPriority]);
+                    unset($this->priorities[$this->maxPriority]);
+                    if ($this->maxPriority === $currentPriority) {
+                        $this->subIndex = 0;
+                    }
+                }
+
+                $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
+                --$this->count;
+                return true;
+            }
+            $this->next();
+        }
+        return false;
+    }
+
+    /**
+     * Get the total number of elements in the queue
+     *
+     * @return integer
+     */
+    public function count()
+    {
+        return $this->count;
+    }
+
+    /**
+     * Get the current element in the queue
+     *
+     * @return mixed
+     */
+    public function current()
+    {
+        switch ($this->extractFlag) {
+            case self::EXTR_DATA:
+                return current($this->values[$this->maxPriority]);
+            case self::EXTR_PRIORITY:
+                return $this->maxPriority;
+            case self::EXTR_BOTH:
+                return [
+                    'data'     => current($this->values[$this->maxPriority]),
+                    'priority' => $this->maxPriority,
+                ];
+        }
+    }
+
+    /**
+     * Get the index of the current element in the queue
+     *
+     * @return integer
+     */
+    public function key()
+    {
+        return $this->index;
+    }
+
+    /**
+     * Set the iterator pointer to the next element in the queue
+     * removing the previous element
+     *
+     * @return void
+     */
+    protected function nextAndRemove()
+    {
+        $key = key($this->values[$this->maxPriority]);
+
+        if (false === next($this->values[$this->maxPriority])) {
+            unset($this->priorities[$this->maxPriority]);
+            unset($this->values[$this->maxPriority]);
+            $this->maxPriority = empty($this->priorities) ? null : max($this->priorities);
+            $this->subIndex    = -1;
+        } else {
+            unset($this->values[$this->maxPriority][$key]);
+        }
+        ++$this->index;
+        ++$this->subIndex;
+        --$this->count;
+    }
+
+    /**
+     * Set the iterator pointer to the next element in the queue
+     * without removing the previous element
+     */
+    public function next()
+    {
+        if (false === next($this->values[$this->maxPriority])) {
+            unset($this->subPriorities[$this->maxPriority]);
+            reset($this->values[$this->maxPriority]);
+            $this->maxPriority = empty($this->subPriorities) ? null : max($this->subPriorities);
+            $this->subIndex    = -1;
+        }
+        ++$this->index;
+        ++$this->subIndex;
+    }
+
+    /**
+     * Check if the current iterator is valid
+     *
+     * @return boolean
+     */
+    public function valid()
+    {
+        return isset($this->values[$this->maxPriority]);
+    }
+
+    /**
+     * Rewind the current iterator
+     */
+    public function rewind()
+    {
+        $this->subPriorities = $this->priorities;
+        $this->maxPriority   = empty($this->priorities) ? 0 : max($this->priorities);
+        $this->index         = 0;
+        $this->subIndex      = 0;
+    }
+
+    /**
+     * Serialize to an array
+     *
+     * Array will be priority => data pairs
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = [];
+        foreach (clone $this as $item) {
+            $array[] = $item;
+        }
+        return $array;
+    }
+
+    /**
+     * Serialize
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        $clone = clone $this;
+        $clone->setExtractFlags(self::EXTR_BOTH);
+
+        $data = [];
+        foreach ($clone as $item) {
+            $data[] = $item;
+        }
+
+        return serialize($data);
+    }
+
+    /**
+     * Deserialize
+     *
+     * @param  string $data
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        foreach (unserialize($data) as $item) {
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+    /**
+     * Set the extract flag
+     *
+     * @param integer $flag
+     * @return void
+     */
+    public function setExtractFlags($flag)
+    {
+        switch ($flag) {
+            case self::EXTR_DATA:
+            case self::EXTR_PRIORITY:
+            case self::EXTR_BOTH:
+                $this->extractFlag = $flag;
+                break;
+            default:
+                throw new Exception\InvalidArgumentException("The extract flag specified is not valid");
+        }
+    }
+
+    /**
+     * Check if the queue is empty
+     *
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return empty($this->values);
+    }
+
+    /**
+     * Does the queue contain the given datum?
+     *
+     * @param  mixed $datum
+     * @return bool
+     */
+    public function contains($datum)
+    {
+        foreach ($this->values as $values) {
+            if (in_array($datum, $values)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Does the queue have an item with the given priority?
+     *
+     * @param  int $priority
+     * @return bool
+     */
+    public function hasPriority($priority)
+    {
+        return isset($this->values[$priority]);
+    }
+}

--- a/src/Parameters/LegacyImplementation.php
+++ b/src/Parameters/LegacyImplementation.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\Parameters;
 
-use ArrayObject as PhpArrayObject;
+use ArrayObject;
+use Laminas\Stdlib\ParametersInterface;
 
 use function http_build_query;
 use function parse_str;
 
-class Parameters extends PhpArrayObject implements ParametersInterface
+class LegacyImplementation extends ArrayObject implements ParametersInterface
 {
     /**
      * Constructor

--- a/src/Parameters/LegacyImplementation.php
+++ b/src/Parameters/LegacyImplementation.php
@@ -105,7 +105,7 @@ class LegacyImplementation extends ArrayObject implements ParametersInterface
     /**
      * @param string $name
      * @param mixed $value
-     * @return $this
+     * @return static
      */
     public function set($name, $value)
     {

--- a/src/Parameters/LegacyImplementation.php
+++ b/src/Parameters/LegacyImplementation.php
@@ -105,7 +105,7 @@ class LegacyImplementation extends ArrayObject implements ParametersInterface
     /**
      * @param string $name
      * @param mixed $value
-     * @return Parameters
+     * @return $this
      */
     public function set($name, $value)
     {

--- a/src/Parameters/PHP81Implementation.php
+++ b/src/Parameters/PHP81Implementation.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\Parameters;
+
+use ArrayObject;
+use Laminas\Stdlib\ParametersInterface;
+
+use function http_build_query;
+use function parse_str;
+
+class PHP81Implementation extends ArrayObject implements ParametersInterface
+{
+    /**
+     * Constructor
+     *
+     * Enforces that we have an array, and enforces parameter access to array
+     * elements.
+     *
+     * @param  array $values
+     */
+    public function __construct(?array $values = null)
+    {
+        if (null === $values) {
+            $values = [];
+        }
+        parent::__construct($values, ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    /**
+     * Populate from native PHP array
+     *
+     * @param  array $values
+     * @return void
+     */
+    public function fromArray(array $values)
+    {
+        $this->exchangeArray($values);
+    }
+
+    /**
+     * Populate from query string
+     *
+     * @param  string $string
+     * @return void
+     */
+    public function fromString($string)
+    {
+        $array = [];
+        parse_str($string, $array);
+        $this->fromArray($array);
+    }
+
+    /**
+     * Serialize to native PHP array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->getArrayCopy();
+    }
+
+    /**
+     * Serialize to query string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return http_build_query($this->toArray());
+    }
+
+    /**
+     * Retrieve by key
+     *
+     * Returns null if the key does not exist.
+     *
+     * @param  string $name
+     */
+    public function offsetGet($name): mixed
+    {
+        if ($this->offsetExists($name)) {
+            return parent::offsetGet($name);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $default optional default value
+     * @return mixed
+     */
+    public function get($name, $default = null)
+    {
+        if ($this->offsetExists($name)) {
+            return parent::offsetGet($name);
+        }
+        return $default;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return Parameters
+     */
+    public function set($name, $value)
+    {
+        $this[$name] = $value;
+        return $this;
+    }
+}

--- a/src/Parameters/PHP81Implementation.php
+++ b/src/Parameters/PHP81Implementation.php
@@ -104,7 +104,7 @@ class PHP81Implementation extends ArrayObject implements ParametersInterface
     /**
      * @param string $name
      * @param mixed $value
-     * @return $this
+     * @return static
      */
     public function set($name, $value)
     {

--- a/src/Parameters/PHP81Implementation.php
+++ b/src/Parameters/PHP81Implementation.php
@@ -104,7 +104,7 @@ class PHP81Implementation extends ArrayObject implements ParametersInterface
     /**
      * @param string $name
      * @param mixed $value
-     * @return Parameters
+     * @return $this
      */
     public function set($name, $value)
     {

--- a/src/PriorityList/LegacyImplementation.php
+++ b/src/PriorityList/LegacyImplementation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\PriorityList;
 
 use Countable;
 use Exception;
@@ -15,7 +15,7 @@ use function next;
 use function reset;
 use function uasort;
 
-class PriorityList implements Iterator, Countable
+class LegacyImplementation implements Iterator, Countable
 {
     public const EXTR_DATA     = 0x00000001;
     public const EXTR_PRIORITY = 0x00000002;
@@ -270,7 +270,7 @@ class PriorityList implements Iterator, Countable
 
         return array_map(
             function ($item) use ($flag) {
-                return $flag === PriorityList::EXTR_PRIORITY ? $item['priority'] : $item['data'];
+                return $flag === self::EXTR_PRIORITY ? $item['priority'] : $item['data'];
             },
             $this->items
         );

--- a/src/PriorityList/LegacyImplementation.php
+++ b/src/PriorityList/LegacyImplementation.php
@@ -91,7 +91,7 @@ class LegacyImplementation implements Iterator, Countable
     /**
      * @param string $name
      * @param int    $priority
-     * @return $this
+     * @return static
      * @throws Exception
      */
     public function setPriority($name, $priority)

--- a/src/PriorityList/LegacyImplementation.php
+++ b/src/PriorityList/LegacyImplementation.php
@@ -25,6 +25,11 @@ class LegacyImplementation implements Iterator, Countable
      * Internal list of all items.
      *
      * @var array[]
+     * @psalm-var array<array-key, array{
+     *     data: mixed,
+     *     priority: int,
+     *     serial: int
+     * }>
      */
     protected $items = [];
 
@@ -225,9 +230,7 @@ class LegacyImplementation implements Iterator, Countable
      */
     public function next()
     {
-        $node = next($this->items);
-
-        return $node ? $node['data'] : false;
+        next($this->items);
     }
 
     /**
@@ -269,7 +272,8 @@ class LegacyImplementation implements Iterator, Countable
         }
 
         return array_map(
-            function ($item) use ($flag) {
+            /** @return mixed */
+            function (array $item) use ($flag) {
                 return $flag === self::EXTR_PRIORITY ? $item['priority'] : $item['data'];
             },
             $this->items

--- a/src/PriorityList/PHP81Implementation.php
+++ b/src/PriorityList/PHP81Implementation.php
@@ -91,7 +91,7 @@ class PHP81Implementation implements Iterator, Countable
     /**
      * @param string $name
      * @param int    $priority
-     * @return $this
+     * @return static
      * @throws Exception
      */
     public function setPriority($name, $priority)

--- a/src/PriorityList/PHP81Implementation.php
+++ b/src/PriorityList/PHP81Implementation.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\PriorityList;
+
+use Countable;
+use Exception;
+use Iterator;
+
+use function array_map;
+use function current;
+use function key;
+use function next;
+use function reset;
+use function uasort;
+
+class PHP81Implementation implements Iterator, Countable
+{
+    public const EXTR_DATA     = 0x00000001;
+    public const EXTR_PRIORITY = 0x00000002;
+    public const EXTR_BOTH     = 0x00000003;
+
+    /**
+     * Internal list of all items.
+     *
+     * @var array[]
+     */
+    protected $items = [];
+
+    /**
+     * Serial assigned to items to preserve LIFO.
+     *
+     * @var int
+     */
+    protected $serial = 0;
+
+    // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCapsProperty
+
+    /**
+     * Serial order mode
+     *
+     * @var integer
+     */
+    protected $isLIFO = 1;
+
+    // phpcs:enable
+
+    /**
+     * Internal counter to avoid usage of count().
+     *
+     * @var int
+     */
+    protected $count = 0;
+
+    /**
+     * Whether the list was already sorted.
+     *
+     * @var bool
+     */
+    protected $sorted = false;
+
+    /**
+     * Insert a new item.
+     *
+     * @param  string  $name
+     * @param  mixed   $value
+     * @param  int     $priority
+     * @return void
+     */
+    public function insert($name, $value, $priority = 0)
+    {
+        if (! isset($this->items[$name])) {
+            $this->count++;
+        }
+
+        $this->sorted = false;
+
+        $this->items[$name] = [
+            'data'     => $value,
+            'priority' => (int) $priority,
+            'serial'   => $this->serial++,
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @param int    $priority
+     * @return $this
+     * @throws Exception
+     */
+    public function setPriority($name, $priority)
+    {
+        if (! isset($this->items[$name])) {
+            throw new Exception("item $name not found");
+        }
+
+        $this->items[$name]['priority'] = (int) $priority;
+        $this->sorted                   = false;
+
+        return $this;
+    }
+
+    /**
+     * Remove a item.
+     *
+     * @param  string $name
+     * @return void
+     */
+    public function remove($name)
+    {
+        if (isset($this->items[$name])) {
+            $this->count--;
+        }
+
+        unset($this->items[$name]);
+    }
+
+    /**
+     * Remove all items.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->items  = [];
+        $this->serial = 0;
+        $this->count  = 0;
+        $this->sorted = false;
+    }
+
+    /**
+     * Get a item.
+     *
+     * @param  string $name
+     * @return mixed
+     */
+    public function get($name)
+    {
+        if (! isset($this->items[$name])) {
+            return;
+        }
+
+        return $this->items[$name]['data'];
+    }
+
+    /**
+     * Sort all items.
+     *
+     * @return void
+     */
+    protected function sort()
+    {
+        if (! $this->sorted) {
+            uasort($this->items, [$this, 'compare']);
+            $this->sorted = true;
+        }
+    }
+
+    /**
+     * Compare the priority of two items.
+     *
+     * @param  array $item1,
+     * @param  array $item2
+     * @return int
+     */
+    protected function compare(array $item1, array $item2)
+    {
+        return $item1['priority'] === $item2['priority']
+            ? ($item1['serial'] > $item2['serial'] ? -1 : 1) * $this->isLIFO
+            : ($item1['priority'] > $item2['priority'] ? -1 : 1);
+    }
+
+    /**
+     * Get/Set serial order mode
+     *
+     * @param bool|null $flag
+     * @return bool
+     */
+    public function isLIFO($flag = null)
+    {
+        if ($flag !== null) {
+            $isLifo = $flag === true ? 1 : -1;
+
+            if ($isLifo !== $this->isLIFO) {
+                $this->isLIFO = $isLifo;
+                $this->sorted = false;
+            }
+        }
+
+        return 1 === $this->isLIFO;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rewind(): void
+    {
+        $this->sort();
+        reset($this->items);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function current(): mixed
+    {
+        $this->sorted || $this->sort();
+        $node = current($this->items);
+
+        return $node ? $node['data'] : false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function key(): mixed
+    {
+        $this->sorted || $this->sort();
+        return key($this->items);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function next(): void
+    {
+        next($this->items);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function valid(): bool
+    {
+        return current($this->items) !== false;
+    }
+
+    /**
+     * @return self
+     */
+    public function getIterator()
+    {
+        return clone $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * Return list as array
+     *
+     * @param int $flag
+     * @return array
+     */
+    public function toArray($flag = self::EXTR_DATA)
+    {
+        $this->sort();
+
+        if ($flag === self::EXTR_BOTH) {
+            return $this->items;
+        }
+
+        return array_map(
+            function ($item) use ($flag) {
+                return $flag === self::EXTR_PRIORITY ? $item['priority'] : $item['data'];
+            },
+            $this->items
+        );
+    }
+}

--- a/src/PriorityList/PHP81Implementation.php
+++ b/src/PriorityList/PHP81Implementation.php
@@ -25,6 +25,11 @@ class PHP81Implementation implements Iterator, Countable
      * Internal list of all items.
      *
      * @var array[]
+     * @psalm-var array<array-key, array{
+     *     data: mixed,
+     *     priority: int,
+     *     serial: int
+     * }>
      */
     protected $items = [];
 
@@ -267,7 +272,7 @@ class PHP81Implementation implements Iterator, Countable
         }
 
         return array_map(
-            function ($item) use ($flag) {
+            function (array $item) use ($flag): mixed {
                 return $flag === self::EXTR_PRIORITY ? $item['priority'] : $item['data'];
             },
             $this->items

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -240,7 +240,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -11,6 +11,7 @@ use Serializable;
 use function array_map;
 use function count;
 use function get_class;
+use function is_array;
 use function serialize;
 use function sprintf;
 use function unserialize;
@@ -236,15 +237,15 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
         foreach ($data as $item) {
-            $this->insert($item['data'], $item['priority']);
+            $this->insert($item['data'], (int) $item['priority']);
         }
     }
 
@@ -299,6 +300,10 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     public function contains($datum)
     {
         foreach ($this->items as $item) {
+            if (! is_array($item) || ! isset($item['data'])) {
+                continue;
+            }
+
             if ($item['data'] === $datum) {
                 return true;
             }
@@ -315,6 +320,10 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     public function hasPriority($priority)
     {
         foreach ($this->items as $item) {
+            if (! is_array($item) || ! isset($item['priority'])) {
+                continue;
+            }
+
             if ($item['priority'] === $priority) {
                 return true;
             }

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -211,6 +211,16 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->items;
+    }
+
+    /**
      * Unserialize a string into a PriorityQueue object
      *
      * Serialization format is compatible with {@link Laminas\Stdlib\SplPriorityQueue}
@@ -221,6 +231,19 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/src/PriorityQueue/LegacyImplementation.php
+++ b/src/PriorityQueue/LegacyImplementation.php
@@ -73,7 +73,7 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      *
      * @param  mixed $data
      * @param  int $priority
-     * @return $this
+     * @return static
      */
     public function insert($data, $priority = 1)
     {
@@ -319,7 +319,7 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      * internal queue class. The class provided should extend SplPriorityQueue.
      *
      * @param  string $class
-     * @return $this
+     * @return static
      */
     public function setInternalQueueClass($class)
     {

--- a/src/PriorityQueue/LegacyImplementation.php
+++ b/src/PriorityQueue/LegacyImplementation.php
@@ -9,11 +9,15 @@ use IteratorAggregate;
 use Laminas\Stdlib\Exception;
 use Laminas\Stdlib\SplPriorityQueue;
 use Serializable;
+use UnexpectedValueException;
 
+use function array_key_exists;
 use function array_map;
 use function count;
 use function get_class;
+use function gettype;
 use function is_array;
+use function is_object;
 use function serialize;
 use function sprintf;
 use function unserialize;
@@ -48,13 +52,17 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      * with keys "data" and "priority".
      *
      * @var array
+     * @psalm-var array<array-key, array{
+     *     data: mixed,
+     *     priority: int
+     * }>
      */
     protected $items = [];
 
     /**
      * Inner queue object
      *
-     * @var SplPriorityQueue
+     * @var null|SplPriorityQueue
      */
     protected $queue;
 
@@ -65,7 +73,7 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      *
      * @param  mixed $data
      * @param  int $priority
-     * @return PriorityQueue
+     * @return $this
      */
     public function insert($data, $priority = 1)
     {
@@ -96,15 +104,16 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      */
     public function remove($datum)
     {
-        $found = false;
+        $keyToRemove = null;
         foreach ($this->items as $key => $item) {
             if ($item['data'] === $datum) {
-                $found = true;
+                $keyToRemove = $key;
                 break;
             }
         }
-        if ($found) {
-            unset($this->items[$key]);
+
+        if ($keyToRemove !== null) {
+            unset($this->items[$keyToRemove]);
             $this->queue = null;
 
             if (! $this->isEmpty()) {
@@ -113,8 +122,10 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
                     $queue->insert($item['data'], $item['priority']);
                 }
             }
+
             return true;
         }
+
         return false;
     }
 
@@ -233,9 +244,15 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->insert($item['data'], $item['priority']);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Unable to deserialize to Laminas\Stdlib\PriorityQueue; expected array, received %s',
+                is_object($toUnserialize) ? get_class($toUnserialize) : gettype($toUnserialize)
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**
@@ -247,7 +264,18 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
     public function __unserialize($data)
     {
         foreach ($data as $item) {
-            $this->insert($item['data'], (int) $item['priority']);
+            if (! is_array($item) || ! array_key_exists('data', $item)) {
+                throw new UnexpectedValueException(
+                    'Unable to deserialize to Laminas\Stdlib\PriorityQueue; corrupt item'
+                );
+            }
+
+            $priority = 1;
+            if (array_key_exists('priority', $item)) {
+                $priority = (int) $item['priority'];
+            }
+
+            $this->insert($item['data'], $priority);
         }
     }
 
@@ -266,14 +294,20 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
         switch ($flag) {
             case self::EXTR_BOTH:
                 return $this->items;
+
             case self::EXTR_PRIORITY:
-                return array_map(function ($item) {
-                    return $item['priority'];
+                return array_map(function (array $item): int {
+                    $priority = 1;
+                    if (array_key_exists('priority', $item)) {
+                        $priority = (int) $item['priority'];
+                    }
+                    return $priority;
                 }, $this->items);
+
             case self::EXTR_DATA:
             default:
-                return array_map(function ($item) {
-                    return $item['data'];
+                return array_map(function (array $item) {
+                    return $item['data'] ?? null;
                 }, $this->items);
         }
     }
@@ -285,7 +319,7 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
      * internal queue class. The class provided should extend SplPriorityQueue.
      *
      * @param  string $class
-     * @return PriorityQueue
+     * @return $this
      */
     public function setInternalQueueClass($class)
     {
@@ -342,14 +376,17 @@ class LegacyImplementation implements Countable, IteratorAggregate, Serializable
     protected function getQueue()
     {
         if (null === $this->queue) {
-            $this->queue = new $this->queueClass();
-            if (! $this->queue instanceof \SplPriorityQueue) {
+            $queue = new $this->queueClass();
+            if (! $queue instanceof SplPriorityQueue) {
                 throw new Exception\DomainException(sprintf(
                     'PriorityQueue expects an internal queue of type SplPriorityQueue; received "%s"',
-                    get_class($this->queue)
+                    get_class($queue)
                 ));
             }
+
+            $this->queue = $queue;
         }
+
         return $this->queue;
     }
 

--- a/src/PriorityQueue/LegacyImplementation.php
+++ b/src/PriorityQueue/LegacyImplementation.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\PriorityQueue;
 
 use Countable;
 use IteratorAggregate;
+use Laminas\Stdlib\Exception;
+use Laminas\Stdlib\SplPriorityQueue;
 use Serializable;
 
 use function array_map;
@@ -28,7 +30,7 @@ use function unserialize;
  * "inner" iterator in the form of an SplPriorityQueue object for performing
  * the actual iteration.
  */
-class PriorityQueue implements Countable, IteratorAggregate, Serializable
+class LegacyImplementation implements Countable, IteratorAggregate, Serializable
 {
     public const EXTR_DATA     = 0x00000001;
     public const EXTR_PRIORITY = 0x00000002;

--- a/src/PriorityQueue/PHP81Implementation.php
+++ b/src/PriorityQueue/PHP81Implementation.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\PriorityQueue;
+
+use Countable;
+use IteratorAggregate;
+use Laminas\Stdlib\Exception;
+use Laminas\Stdlib\SplPriorityQueue;
+use Serializable;
+use Traversable;
+
+use function array_map;
+use function count;
+use function get_class;
+use function is_array;
+use function serialize;
+use function sprintf;
+use function unserialize;
+
+/**
+ * Re-usable, serializable priority queue implementation
+ *
+ * SplPriorityQueue acts as a heap; on iteration, each item is removed from the
+ * queue. If you wish to re-use such a queue, you need to clone it first. This
+ * makes for some interesting issues if you wish to delete items from the queue,
+ * or, as already stated, iterate over it multiple times.
+ *
+ * This class aggregates items for the queue itself, but also composes an
+ * "inner" iterator in the form of an SplPriorityQueue object for performing
+ * the actual iteration.
+ */
+class PHP81Implementation implements Countable, IteratorAggregate, Serializable
+{
+    public const EXTR_DATA     = 0x00000001;
+    public const EXTR_PRIORITY = 0x00000002;
+    public const EXTR_BOTH     = 0x00000003;
+
+    /**
+     * Inner queue class to use for iteration
+     *
+     * @var string
+     */
+    protected $queueClass = SplPriorityQueue::class;
+
+    /**
+     * Actual items aggregated in the priority queue. Each item is an array
+     * with keys "data" and "priority".
+     *
+     * @var array
+     */
+    protected $items = [];
+
+    /**
+     * Inner queue object
+     *
+     * @var SplPriorityQueue
+     */
+    protected $queue;
+
+    /**
+     * Insert an item into the queue
+     *
+     * Priority defaults to 1 (low priority) if none provided.
+     *
+     * @param  mixed $data
+     * @param  int $priority
+     * @return PriorityQueue
+     */
+    public function insert($data, $priority = 1)
+    {
+        $priority      = (int) $priority;
+        $this->items[] = [
+            'data'     => $data,
+            'priority' => $priority,
+        ];
+        $this->getQueue()->insert($data, $priority);
+        return $this;
+    }
+
+    /**
+     * Remove an item from the queue
+     *
+     * This is different than {@link extract()}; its purpose is to dequeue an
+     * item.
+     *
+     * This operation is potentially expensive, as it requires
+     * re-initialization and re-population of the inner queue.
+     *
+     * Note: this removes the first item matching the provided item found. If
+     * the same item has been added multiple times, it will not remove other
+     * instances.
+     *
+     * @param  mixed $datum
+     * @return bool False if the item was not found, true otherwise.
+     */
+    public function remove($datum)
+    {
+        $found = false;
+        foreach ($this->items as $key => $item) {
+            if ($item['data'] === $datum) {
+                $found = true;
+                break;
+            }
+        }
+        if ($found) {
+            unset($this->items[$key]);
+            $this->queue = null;
+
+            if (! $this->isEmpty()) {
+                $queue = $this->getQueue();
+                foreach ($this->items as $item) {
+                    $queue->insert($item['data'], $item['priority']);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Is the queue empty?
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return 0 === $this->count();
+    }
+
+    /**
+     * How many items are in the queue?
+     */
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Peek at the top node in the queue, based on priority.
+     *
+     * @return mixed
+     */
+    public function top()
+    {
+        return $this->getIterator()->top();
+    }
+
+    /**
+     * Extract a node from the inner queue and sift up
+     *
+     * @return mixed
+     */
+    public function extract()
+    {
+        $value = $this->getQueue()->extract();
+
+        $keyToRemove     = null;
+        $highestPriority = null;
+        foreach ($this->items as $key => $item) {
+            if ($item['data'] !== $value) {
+                continue;
+            }
+
+            if (null === $highestPriority) {
+                $highestPriority = $item['priority'];
+                $keyToRemove     = $key;
+                continue;
+            }
+
+            if ($highestPriority >= $item['priority']) {
+                continue;
+            }
+
+            $highestPriority = $item['priority'];
+            $keyToRemove     = $key;
+        }
+
+        if ($keyToRemove !== null) {
+            unset($this->items[$keyToRemove]);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Retrieve the inner iterator
+     *
+     * SplPriorityQueue acts as a heap, which typically implies that as items
+     * are iterated, they are also removed. This does not work for situations
+     * where the queue may be iterated multiple times. As such, this class
+     * aggregates the values, and also injects an SplPriorityQueue. This method
+     * retrieves the inner queue object, and clones it for purposes of
+     * iteration.
+     *
+     * @return SplPriorityQueue
+     */
+    public function getIterator(): Traversable
+    {
+        $queue = $this->getQueue();
+        return clone $queue;
+    }
+
+    /**
+     * Serialize the data structure
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize($this->items);
+    }
+
+    /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Unserialize a string into a PriorityQueue object
+     *
+     * Serialization format is compatible with {@link Laminas\Stdlib\SplPriorityQueue}
+     *
+     * @param  string $data
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        foreach (unserialize($data) as $item) {
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+   /**
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
+            $this->insert($item['data'], (int) $item['priority']);
+        }
+    }
+
+    /**
+     * Serialize to an array
+     *
+     * By default, returns only the item data, and in the order registered (not
+     * sorted). You may provide one of the EXTR_* flags as an argument, allowing
+     * the ability to return priorities or both data and priority.
+     *
+     * @param  int $flag
+     * @return array
+     */
+    public function toArray($flag = self::EXTR_DATA)
+    {
+        switch ($flag) {
+            case self::EXTR_BOTH:
+                return $this->items;
+            case self::EXTR_PRIORITY:
+                return array_map(function ($item) {
+                    return $item['priority'];
+                }, $this->items);
+            case self::EXTR_DATA:
+            default:
+                return array_map(function ($item) {
+                    return $item['data'];
+                }, $this->items);
+        }
+    }
+
+    /**
+     * Specify the internal queue class
+     *
+     * Please see {@link getIterator()} for details on the necessity of an
+     * internal queue class. The class provided should extend SplPriorityQueue.
+     *
+     * @param  string $class
+     * @return PriorityQueue
+     */
+    public function setInternalQueueClass($class)
+    {
+        $this->queueClass = (string) $class;
+        return $this;
+    }
+
+    /**
+     * Does the queue contain the given datum?
+     *
+     * @param  mixed $datum
+     * @return bool
+     */
+    public function contains($datum)
+    {
+        foreach ($this->items as $item) {
+            if (! is_array($item) || ! isset($item['data'])) {
+                continue;
+            }
+
+            if ($item['data'] === $datum) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Does the queue have an item with the given priority?
+     *
+     * @param  int $priority
+     * @return bool
+     */
+    public function hasPriority($priority)
+    {
+        foreach ($this->items as $item) {
+            if (! is_array($item) || ! isset($item['priority'])) {
+                continue;
+            }
+
+            if ($item['priority'] === $priority) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the inner priority queue instance
+     *
+     * @throws Exception\DomainException
+     * @return SplPriorityQueue
+     */
+    protected function getQueue()
+    {
+        if (null === $this->queue) {
+            $this->queue = new $this->queueClass();
+            if (! $this->queue instanceof \SplPriorityQueue) {
+                throw new Exception\DomainException(sprintf(
+                    'PriorityQueue expects an internal queue of type SplPriorityQueue; received "%s"',
+                    get_class($this->queue)
+                ));
+            }
+        }
+        return $this->queue;
+    }
+
+    /**
+     * Add support for deep cloning
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        if (null !== $this->queue) {
+            $this->queue = clone $this->queue;
+        }
+    }
+}

--- a/src/PriorityQueue/PHP81Implementation.php
+++ b/src/PriorityQueue/PHP81Implementation.php
@@ -74,7 +74,7 @@ class PHP81Implementation implements Countable, IteratorAggregate, Serializable
      *
      * @param  mixed $data
      * @param  int $priority
-     * @return $this
+     * @return static
      */
     public function insert($data, $priority = 1)
     {
@@ -318,7 +318,7 @@ class PHP81Implementation implements Countable, IteratorAggregate, Serializable
      * internal queue class. The class provided should extend SplPriorityQueue.
      *
      * @param  string $class
-     * @return $this
+     * @return static
      */
     public function setInternalQueueClass($class)
     {

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -89,7 +89,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         foreach ($clone as $item) {
             $data[] = $item;
         }
-		return $data;
+        return $data;
     }
 	
     /**

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -76,6 +76,23 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $clone = clone $this;
+        $clone->setExtractFlags(self::EXTR_BOTH);
+
+        $data = [];
+        foreach ($clone as $item) {
+            $data[] = $item;
+        }
+		return $data;
+    }
+	
+    /**
      * Deserialize
      *
      * @param  string $data
@@ -85,6 +102,21 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
     {
         $this->serial = PHP_INT_MAX;
         foreach (unserialize($data) as $item) {
+            $this->serial--;
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        $this->serial = PHP_INT_MAX;
+        foreach ($data as $item) {
             $this->serial--;
             $this->insert($item['data'], $item['priority']);
         }

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -91,7 +91,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         }
         return $data;
     }
-	
+
     /**
      * Deserialize
      *
@@ -112,7 +112,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         $this->serial = PHP_INT_MAX;

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -107,7 +107,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         }
     }
 
-   /**
+    /**
      * Magic method used to rebuild an instance.
      *
      * @param array $data Data array.

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -66,7 +66,7 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -39,6 +39,16 @@ class SplQueue extends \SplQueue implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Unserialize
      *
      * @param  string $data
@@ -47,6 +57,19 @@ class SplQueue extends \SplQueue implements Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->push($item);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->push($item);
         }
     }

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -62,13 +62,14 @@ class SplQueue extends \SplQueue implements Serializable
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
+        /** @psalm-suppress MixedAssignment */
         foreach ($data as $item) {
             $this->push($item);
         }

--- a/src/SplQueue/LegacyImplementation.php
+++ b/src/SplQueue/LegacyImplementation.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\SplQueue;
+
+use Serializable;
+use SplQueue;
+
+use function serialize;
+use function unserialize;
+
+/**
+ * Serializable version of SplQueue
+ */
+class LegacyImplementation extends SplQueue implements Serializable
+{
+    /**
+     * Return an array representing the queue
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = [];
+        foreach ($this as $item) {
+            $array[] = $item;
+        }
+        return $array;
+    }
+
+    /**
+     * Serialize
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize($this->toArray());
+    }
+
+    /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Unserialize
+     *
+     * @param  string $data
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        foreach (unserialize($data) as $item) {
+            $this->push($item);
+        }
+    }
+
+   /**
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
+    public function __unserialize($data)
+    {
+        /** @psalm-suppress MixedAssignment */
+        foreach ($data as $item) {
+            $this->push($item);
+        }
+    }
+}

--- a/src/SplQueue/LegacyImplementation.php
+++ b/src/SplQueue/LegacyImplementation.php
@@ -6,8 +6,14 @@ namespace Laminas\Stdlib\SplQueue;
 
 use Serializable;
 use SplQueue;
+use UnexpectedValueException;
 
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_object;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 /**
@@ -57,9 +63,15 @@ class LegacyImplementation extends SplQueue implements Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->push($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Unable to deserialize to Laminas\Stdlib\SplQueue; expected array, received %s',
+                is_object($toUnserialize) ? get_class($toUnserialize) : gettype($toUnserialize)
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**

--- a/src/SplQueue/PHP81Implementation.php
+++ b/src/SplQueue/PHP81Implementation.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib\SplQueue;
+
+use SplQueue;
+
+use function serialize;
+use function unserialize;
+
+/**
+ * Serializable version of SplQueue
+ */
+class PHP81Implementation extends SplQueue
+{
+    /**
+     * Return an array representing the queue
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = [];
+        foreach ($this as $item) {
+            $array[] = $item;
+        }
+        return $array;
+    }
+
+    /**
+     * Serialize
+     */
+    public function serialize(): string
+    {
+        return serialize($this->toArray());
+    }
+
+    /**
+     * Magic method used for serializing of an instance.
+     */
+    public function __serialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Unserialize
+     */
+    public function unserialize(string $data): void
+    {
+        foreach (unserialize($data) as $item) {
+            $this->push($item);
+        }
+    }
+
+   /**
+    * Magic method used to rebuild an instance.
+    */
+    public function __unserialize(array $data): void
+    {
+        /** @psalm-suppress MixedAssignment */
+        foreach ($data as $item) {
+            $this->push($item);
+        }
+    }
+}

--- a/src/SplQueue/PHP81Implementation.php
+++ b/src/SplQueue/PHP81Implementation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib\SplQueue;
 
 use SplQueue;
+use UnexpectedValueException;
 
 use function serialize;
 use function unserialize;
@@ -49,9 +50,15 @@ class PHP81Implementation extends SplQueue
      */
     public function unserialize(string $data): void
     {
-        foreach (unserialize($data) as $item) {
-            $this->push($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Unable to deserialize to Laminas\Stdlib\SplQueue; expected array, received %s',
+                is_object($toUnserialize) ? get_class($toUnserialize) : gettype($toUnserialize)
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -66,7 +66,7 @@ class SplStack extends \SplStack implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -62,13 +62,14 @@ class SplStack extends \SplStack implements Serializable
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
+        /** @psalm-suppress MixedAssignment */
         foreach ($data as $item) {
             $this->unshift($item);
         }

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -39,6 +39,16 @@ class SplStack extends \SplStack implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Unserialize
      *
      * @param  string $data
@@ -47,6 +57,19 @@ class SplStack extends \SplStack implements Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->unshift($item);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->unshift($item);
         }
     }

--- a/src/SplStack/LegacyImplementation.php
+++ b/src/SplStack/LegacyImplementation.php
@@ -6,8 +6,14 @@ namespace Laminas\Stdlib\SplStack;
 
 use Serializable;
 use SplStack;
+use UnexpectedValueException;
 
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_object;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 /**
@@ -57,9 +63,14 @@ class LegacyImplementation extends SplStack implements Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->unshift($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Unable to deserialize to Laminas\Stdlib\SplStack; expected array, received %s',
+                is_object($toUnserialize) ? get_class($toUnserialize) : gettype($toUnserialize)
+            ));
         }
+        $this->__unserialize($toUnserialize);
     }
 
    /**

--- a/src/SplStack/LegacyImplementation.php
+++ b/src/SplStack/LegacyImplementation.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\SplStack;
 
 use Serializable;
+use SplStack;
 
 use function serialize;
 use function unserialize;
@@ -12,7 +13,7 @@ use function unserialize;
 /**
  * Serializable version of SplStack
  */
-class SplStack extends \SplStack implements Serializable
+class LegacyImplementation extends SplStack implements Serializable
 {
     /**
      * Serialize to an array representing the stack

--- a/src/SplStack/PHP81Implementation.php
+++ b/src/SplStack/PHP81Implementation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib\SplStack;
 
 use SplStack;
+use UnexpectedValueException;
 
 use function serialize;
 use function unserialize;
@@ -49,9 +50,14 @@ class PHP81Implementation extends SplStack
      */
     public function unserialize(string $data): void
     {
-        foreach (unserialize($data) as $item) {
-            $this->unshift($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Unable to deserialize to Laminas\Stdlib\SplStack; expected array, received %s',
+                is_object($toUnserialize) ? get_class($toUnserialize) : gettype($toUnserialize)
+            ));
         }
+        $this->__unserialize($toUnserialize);
     }
 
    /**

--- a/src/SplStack/PHP81Implementation.php
+++ b/src/SplStack/PHP81Implementation.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Laminas\Stdlib;
+namespace Laminas\Stdlib\SplStack;
 
-use Serializable;
+use SplStack;
 
 use function serialize;
 use function unserialize;
 
 /**
- * Serializable version of SplQueue
+ * Serializable version of SplStack
  */
-class SplQueue extends \SplQueue implements Serializable
+class PHP81Implementation extends SplStack
 {
     /**
-     * Return an array representing the queue
+     * Serialize to an array representing the stack
      *
      * @return array
      */
@@ -30,48 +30,38 @@ class SplQueue extends \SplQueue implements Serializable
 
     /**
      * Serialize
-     *
-     * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->toArray());
     }
 
     /**
      * Magic method used for serializing of an instance.
-     *
-     * @return array
      */
-    public function __serialize()
+    public function __serialize(): array
     {
         return $this->toArray();
     }
 
     /**
      * Unserialize
-     *
-     * @param  string $data
-     * @return void
      */
-    public function unserialize($data)
+    public function unserialize(string $data): void
     {
         foreach (unserialize($data) as $item) {
-            $this->push($item);
+            $this->unshift($item);
         }
     }
 
    /**
     * Magic method used to rebuild an instance.
-    *
-    * @param array $data Data array.
-    * @return void
     */
-    public function __unserialize($data)
+    public function __unserialize(array $data): void
     {
         /** @psalm-suppress MixedAssignment */
         foreach ($data as $item) {
-            $this->push($item);
+            $this->unshift($item);
         }
     }
 }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,65 @@
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
+
+declare(strict_types=1);
+
+namespace Laminas\Stdlib;
+
+use function class_alias;
+
+use const PHP_VERSION_ID;
+
+// Laminas\Stdlib\ArrayObject
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? ArrayObject\PHP81Implementation::class
+    : ArrayObject\LegacyImplementation::class,
+    ArrayObject::class
+);
+
+// Laminas\Stdlib\FastPriorityQueue
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? FastPriorityQueue\PHP81Implementation::class
+    : FastPriorityQueue\LegacyImplementation::class,
+    FastPriorityQueue::class
+);
+
+// Laminas\Stdlib\Parameters
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? Parameters\PHP81Implementation::class
+    : Parameters\LegacyImplementation::class,
+    Parameters::class
+);
+
+// Laminas\Stdlib\PriorityList
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? PriorityList\PHP81Implementation::class
+    : PriorityList\LegacyImplementation::class,
+    PriorityList::class
+);
+
+// Laminas\Stdlib\PriorityQueue
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? PriorityQueue\PHP81Implementation::class
+    : PriorityQueue\LegacyImplementation::class,
+    PriorityQueue::class
+);
+
+// Laminas\Stdlib\SplQueue
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? SplQueue\PHP81Implementation::class
+    : SplQueue\LegacyImplementation::class,
+    SplQueue::class
+);
+
+// Laminas\Stdlib\SplStack
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? SplStack\PHP81Implementation::class
+    : SplStack\LegacyImplementation::class,
+    SplStack::class
+);

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -8,58 +8,50 @@ use function class_alias;
 
 use const PHP_VERSION_ID;
 
-// Laminas\Stdlib\ArrayObject
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? ArrayObject\PHP81Implementation::class
-    : ArrayObject\LegacyImplementation::class,
-    ArrayObject::class
-);
+// PHP < 8.1
+if (PHP_VERSION_ID < 80100) {
+    // Laminas\Stdlib\ArrayObject
+    class_alias(ArrayObject\LegacyImplementation::class, ArrayObject::class);
 
-// Laminas\Stdlib\FastPriorityQueue
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? FastPriorityQueue\PHP81Implementation::class
-    : FastPriorityQueue\LegacyImplementation::class,
-    FastPriorityQueue::class
-);
+    // Laminas\Stdlib\FastPriorityQueue
+    class_alias(FastPriorityQueue\LegacyImplementation::class, FastPriorityQueue::class);
 
-// Laminas\Stdlib\Parameters
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? Parameters\PHP81Implementation::class
-    : Parameters\LegacyImplementation::class,
-    Parameters::class
-);
+    // Laminas\Stdlib\Parameters
+    class_alias(Parameters\LegacyImplementation::class, Parameters::class);
 
-// Laminas\Stdlib\PriorityList
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? PriorityList\PHP81Implementation::class
-    : PriorityList\LegacyImplementation::class,
-    PriorityList::class
-);
+    // Laminas\Stdlib\PriorityList
+    class_alias(PriorityList\LegacyImplementation::class, PriorityList::class);
 
-// Laminas\Stdlib\PriorityQueue
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? PriorityQueue\PHP81Implementation::class
-    : PriorityQueue\LegacyImplementation::class,
-    PriorityQueue::class
-);
+    // Laminas\Stdlib\PriorityQueue
+    class_alias(PriorityQueue\LegacyImplementation::class, PriorityQueue::class);
 
-// Laminas\Stdlib\SplQueue
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? SplQueue\PHP81Implementation::class
-    : SplQueue\LegacyImplementation::class,
-    SplQueue::class
-);
+    // Laminas\Stdlib\SplQueue
+    class_alias(SplQueue\LegacyImplementation::class, SplQueue::class);
 
-// Laminas\Stdlib\SplStack
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? SplStack\PHP81Implementation::class
-    : SplStack\LegacyImplementation::class,
-    SplStack::class
-);
+    // Laminas\Stdlib\SplStack
+    class_alias(SplStack\LegacyImplementation::class, SplStack::class);
+}
+
+// PHP 8.1+
+if (PHP_VERSION_ID >= 80100) {
+    // Laminas\Stdlib\ArrayObject
+    class_alias(ArrayObject\PHP81Implementation::class, ArrayObject::class);
+
+    // Laminas\Stdlib\FastPriorityQueue
+    class_alias(FastPriorityQueue\PHP81Implementation::class, FastPriorityQueue::class);
+
+    // Laminas\Stdlib\Parameters
+    class_alias(Parameters\PHP81Implementation::class, Parameters::class);
+
+    // Laminas\Stdlib\PriorityList
+    class_alias(PriorityList\PHP81Implementation::class, PriorityList::class);
+
+    // Laminas\Stdlib\PriorityQueue
+    class_alias(PriorityQueue\PHP81Implementation::class, PriorityQueue::class);
+
+    // Laminas\Stdlib\SplQueue
+    class_alias(SplQueue\PHP81Implementation::class, SplQueue::class);
+
+    // Laminas\Stdlib\SplStack
+    class_alias(SplStack\PHP81Implementation::class, SplStack::class);
+}

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -219,8 +219,9 @@ class ArrayObjectTest extends TestCase
 
     public function testIterator(): void
     {
-        $ar        = new ArrayObject(['1' => 'one', '2' => 'two', '3' => 'three']);
-        $iterator  = $ar->getIterator();
+        $ar       = new ArrayObject(['1' => 'one', '2' => 'two', '3' => 'three']);
+        $iterator = $ar->getIterator();
+        self::assertInstanceOf(ArrayIterator::class, $iterator);
         $iterator2 = new ArrayIterator($ar->getArrayCopy());
         self::assertEquals($iterator2->getArrayCopy(), $iterator->getArrayCopy());
     }

--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -10,7 +10,7 @@ use Laminas\Stdlib\ArrayUtils\MergeRemoveKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
-use Laminas\Stdlib\Parameters;
+use laminas\stdlib\parameters;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Traversable;
@@ -376,7 +376,7 @@ class ArrayUtilsTest extends TestCase
             ],
         ];
         $arrayAccess = new ArrayObject($array);
-        $toArray     = new Parameters($array);
+        $toArray     = new parameters($array);
 
         return [
             // Description => [input, expected array]

--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
@@ -10,7 +10,7 @@ use Laminas\Stdlib\ArrayUtils\MergeRemoveKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
-use laminas\stdlib\parameters;
+use Laminas\Stdlib\Parameters;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Traversable;
@@ -363,7 +363,7 @@ class ArrayUtilsTest extends TestCase
         self::assertEquals($expected, ArrayUtils::merge($a, $b));
     }
 
-    /** @psalm-return array<string, array{0: iterable, 1: array}> */
+    /** @psalm-return array<string, array{0: Traversable|array, 1: array}> */
     public static function validIterators(): array
     {
         $array       = [
@@ -376,7 +376,7 @@ class ArrayUtilsTest extends TestCase
             ],
         ];
         $arrayAccess = new ArrayObject($array);
-        $toArray     = new parameters($array);
+        $toArray     = new Parameters($array);
 
         return [
             // Description => [input, expected array]

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Stdlib;
 
 use Laminas\Stdlib\Exception\InvalidArgumentException;
-use Laminas\Stdlib\FastPriorityQueue;
+use laminas\stdlib\fastpriorityqueue;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -22,7 +22,7 @@ use function var_export;
  */
 class FastPriorityQueueTest extends TestCase
 {
-    /** @var FastPriorityQueue */
+    /** @var fastpriorityqueue */
     protected $queue;
 
     /** @var string[] */
@@ -30,7 +30,7 @@ class FastPriorityQueueTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->queue = new FastPriorityQueue();
+        $this->queue = new fastpriorityqueue();
         $this->insertDataQueue($this->queue);
         $this->expected = [
             'test1',
@@ -55,7 +55,7 @@ class FastPriorityQueueTest extends TestCase
         ];
     }
 
-    protected function insertDataQueue(FastPriorityQueue $queue): void
+    protected function insertDataQueue(fastpriorityqueue $queue): void
     {
         foreach ($this->getDataPriorityQueue() as $value => $priority) {
             $queue->insert($value, $priority);
@@ -90,7 +90,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testMaintainsInsertOrderForDataOfEqualPriority(): void
     {
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         $queue->insert('foo', 1000);
         $queue->insert('bar', 1000);
         $queue->insert('baz', 1000);
@@ -153,11 +153,11 @@ class FastPriorityQueueTest extends TestCase
     public function testSetExtractFlag(): void
     {
         $priorities = $this->getDataPriorityQueue();
-        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_DATA);
+        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_DATA);
         self::assertEquals($this->expected[0], $this->queue->extract());
-        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_PRIORITY);
+        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_PRIORITY);
         self::assertEquals($priorities[$this->expected[1]], $this->queue->extract());
-        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_BOTH);
+        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_BOTH);
         $expected = [
             'data'     => $this->expected[2],
             'priority' => $priorities[$this->expected[2]],
@@ -174,7 +174,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testIsEmpty(): void
     {
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         self::assertTrue($queue->isEmpty());
         $queue->insert('foo', 1);
         self::assertFalse($queue->isEmpty());
@@ -239,7 +239,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testRewindShouldNotRaiseErrorWhenQueueIsEmpty(): void
     {
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         self::assertTrue($queue->isEmpty());
 
         $queue->rewind();
@@ -250,7 +250,7 @@ class FastPriorityQueueTest extends TestCase
         $prototype = function ($e): void {
         };
 
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         self::assertTrue($queue->isEmpty());
 
         $listeners = [];
@@ -272,7 +272,7 @@ class FastPriorityQueueTest extends TestCase
         $prototype = function ($e): void {
         };
 
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         self::assertTrue($queue->isEmpty());
 
         $listeners = [];
@@ -295,7 +295,7 @@ class FastPriorityQueueTest extends TestCase
     public function testRemoveShouldNotAffectExtract(): void
     {
         // Removing an element with low priority
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         $queue->insert('a1', 1);
         $queue->insert('a2', 1);
         $queue->insert('b', 2);
@@ -336,7 +336,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testZeroPriority(): void
     {
-        $queue = new FastPriorityQueue();
+        $queue = new fastpriorityqueue();
         $queue->insert('a', 0);
         $queue->insert('b', 1);
         $expected = ['b', 'a'];

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -1,11 +1,11 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
 use Laminas\Stdlib\Exception\InvalidArgumentException;
-use laminas\stdlib\fastpriorityqueue;
+use Laminas\Stdlib\FastPriorityQueue;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -22,7 +22,7 @@ use function var_export;
  */
 class FastPriorityQueueTest extends TestCase
 {
-    /** @var fastpriorityqueue */
+    /** @var FastPriorityQueue */
     protected $queue;
 
     /** @var string[] */
@@ -30,7 +30,7 @@ class FastPriorityQueueTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->queue = new fastpriorityqueue();
+        $this->queue = new FastPriorityQueue();
         $this->insertDataQueue($this->queue);
         $this->expected = [
             'test1',
@@ -55,7 +55,7 @@ class FastPriorityQueueTest extends TestCase
         ];
     }
 
-    protected function insertDataQueue(fastpriorityqueue $queue): void
+    protected function insertDataQueue(FastPriorityQueue $queue): void
     {
         foreach ($this->getDataPriorityQueue() as $value => $priority) {
             $queue->insert($value, $priority);
@@ -90,7 +90,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testMaintainsInsertOrderForDataOfEqualPriority(): void
     {
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         $queue->insert('foo', 1000);
         $queue->insert('bar', 1000);
         $queue->insert('baz', 1000);
@@ -153,11 +153,11 @@ class FastPriorityQueueTest extends TestCase
     public function testSetExtractFlag(): void
     {
         $priorities = $this->getDataPriorityQueue();
-        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_DATA);
+        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_DATA);
         self::assertEquals($this->expected[0], $this->queue->extract());
-        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_PRIORITY);
+        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_PRIORITY);
         self::assertEquals($priorities[$this->expected[1]], $this->queue->extract());
-        $this->queue->setExtractFlags(fastpriorityqueue::EXTR_BOTH);
+        $this->queue->setExtractFlags(FastPriorityQueue::EXTR_BOTH);
         $expected = [
             'data'     => $this->expected[2],
             'priority' => $priorities[$this->expected[2]],
@@ -174,7 +174,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testIsEmpty(): void
     {
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         self::assertTrue($queue->isEmpty());
         $queue->insert('foo', 1);
         self::assertFalse($queue->isEmpty());
@@ -239,7 +239,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testRewindShouldNotRaiseErrorWhenQueueIsEmpty(): void
     {
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         self::assertTrue($queue->isEmpty());
 
         $queue->rewind();
@@ -250,7 +250,7 @@ class FastPriorityQueueTest extends TestCase
         $prototype = function ($e): void {
         };
 
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         self::assertTrue($queue->isEmpty());
 
         $listeners = [];
@@ -272,7 +272,7 @@ class FastPriorityQueueTest extends TestCase
         $prototype = function ($e): void {
         };
 
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         self::assertTrue($queue->isEmpty());
 
         $listeners = [];
@@ -295,7 +295,7 @@ class FastPriorityQueueTest extends TestCase
     public function testRemoveShouldNotAffectExtract(): void
     {
         // Removing an element with low priority
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         $queue->insert('a1', 1);
         $queue->insert('a2', 1);
         $queue->insert('b', 2);
@@ -336,7 +336,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testZeroPriority(): void
     {
-        $queue = new fastpriorityqueue();
+        $queue = new FastPriorityQueue();
         $queue->insert('a', 0);
         $queue->insert('b', 1);
         $expected = ['b', 'a'];

--- a/test/Guard/ArrayOrTraversableGuardTraitTest.php
+++ b/test/Guard/ArrayOrTraversableGuardTraitTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib\Guard;
 
-use laminas\stdlib\arrayobject;
+use Laminas\Stdlib\ArrayObject;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use LaminasTest\Stdlib\TestAsset\GuardedObject;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +31,7 @@ class ArrayOrTraversableGuardTraitTest extends TestCase
     public function testGuardForArrayOrTraversableAllowsTraversable(): void
     {
         $object      = new GuardedObject();
-        $traversable = new arrayobject();
+        $traversable = new ArrayObject();
         self::assertNull($object->setArrayOrTraversable($traversable));
     }
 }

--- a/test/Guard/ArrayOrTraversableGuardTraitTest.php
+++ b/test/Guard/ArrayOrTraversableGuardTraitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib\Guard;
 
-use Laminas\Stdlib\ArrayObject;
+use laminas\stdlib\arrayobject;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use LaminasTest\Stdlib\TestAsset\GuardedObject;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +31,7 @@ class ArrayOrTraversableGuardTraitTest extends TestCase
     public function testGuardForArrayOrTraversableAllowsTraversable(): void
     {
         $object      = new GuardedObject();
-        $traversable = new ArrayObject();
+        $traversable = new arrayobject();
         self::assertNull($object->setArrayOrTraversable($traversable));
     }
 }

--- a/test/Guard/NullGuardTraitTest.php
+++ b/test/Guard/NullGuardTraitTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use laminas\stdlib\parameters;
+use Laminas\Stdlib\Parameters;
 use Laminas\Stdlib\ParametersInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +12,7 @@ class ParametersTest extends TestCase
 {
     public function testParametersConstructionAndClassStructure(): void
     {
-        $parameters = new parameters();
+        $parameters = new Parameters();
         self::assertInstanceOf(ParametersInterface::class, $parameters);
         self::assertInstanceOf('ArrayObject', $parameters);
         self::assertInstanceOf('ArrayAccess', $parameters);
@@ -23,7 +23,7 @@ class ParametersTest extends TestCase
 
     public function testParametersPersistNameAndValues(): void
     {
-        $parameters = new parameters(['foo' => 'bar']);
+        $parameters = new Parameters(['foo' => 'bar']);
         self::assertEquals('bar', $parameters['foo']);
         self::assertEquals('bar', $parameters->foo);
         $parameters->offsetSet('baz', 5);
@@ -46,13 +46,13 @@ class ParametersTest extends TestCase
 
     public function testParametersOffsetgetReturnsNullIfNonexistentKeyIsProvided(): void
     {
-        $parameters = new parameters();
+        $parameters = new Parameters();
         self::assertNull($parameters->foo);
     }
 
     public function testParametersGetReturnsDefaultValueIfNonExistent(): void
     {
-        $parameters = new parameters();
+        $parameters = new Parameters();
 
         self::assertEquals(5, $parameters->get('nonExistentProp', 5));
     }

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use Laminas\Stdlib\Parameters;
+use laminas\stdlib\parameters;
 use Laminas\Stdlib\ParametersInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +12,7 @@ class ParametersTest extends TestCase
 {
     public function testParametersConstructionAndClassStructure(): void
     {
-        $parameters = new Parameters();
+        $parameters = new parameters();
         self::assertInstanceOf(ParametersInterface::class, $parameters);
         self::assertInstanceOf('ArrayObject', $parameters);
         self::assertInstanceOf('ArrayAccess', $parameters);
@@ -23,7 +23,7 @@ class ParametersTest extends TestCase
 
     public function testParametersPersistNameAndValues(): void
     {
-        $parameters = new Parameters(['foo' => 'bar']);
+        $parameters = new parameters(['foo' => 'bar']);
         self::assertEquals('bar', $parameters['foo']);
         self::assertEquals('bar', $parameters->foo);
         $parameters->offsetSet('baz', 5);
@@ -46,13 +46,13 @@ class ParametersTest extends TestCase
 
     public function testParametersOffsetgetReturnsNullIfNonexistentKeyIsProvided(): void
     {
-        $parameters = new Parameters();
+        $parameters = new parameters();
         self::assertNull($parameters->foo);
     }
 
     public function testParametersGetReturnsDefaultValueIfNonExistent(): void
     {
-        $parameters = new Parameters();
+        $parameters = new parameters();
 
         self::assertEquals(5, $parameters->get('nonExistentProp', 5));
     }

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use Laminas\Stdlib\PriorityList;
+use laminas\stdlib\prioritylist;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -14,12 +14,12 @@ use function iterator_to_array;
 
 class PriorityListTest extends TestCase
 {
-    /** @var PriorityList */
+    /** @var prioritylist */
     protected $list;
 
     protected function setUp(): void
     {
-        $this->list = new PriorityList();
+        $this->list = new prioritylist();
     }
 
     public function testInsert(): void
@@ -205,7 +205,7 @@ class PriorityListTest extends TestCase
                 'foo' => ['data' => 'foo_value', 'priority' => 0, 'serial' => 0],
                 'baz' => ['data' => 'baz_value', 'priority' => -1, 'serial' => 2],
             ],
-            $this->list->toArray(PriorityList::EXTR_BOTH)
+            $this->list->toArray(prioritylist::EXTR_BOTH)
         );
     }
 

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use laminas\stdlib\prioritylist;
+use Laminas\Stdlib\PriorityList;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -14,12 +14,12 @@ use function iterator_to_array;
 
 class PriorityListTest extends TestCase
 {
-    /** @var prioritylist */
+    /** @var PriorityList */
     protected $list;
 
     protected function setUp(): void
     {
-        $this->list = new prioritylist();
+        $this->list = new PriorityList();
     }
 
     public function testInsert(): void
@@ -205,7 +205,7 @@ class PriorityListTest extends TestCase
                 'foo' => ['data' => 'foo_value', 'priority' => 0, 'serial' => 0],
                 'baz' => ['data' => 'baz_value', 'priority' => -1, 'serial' => 2],
             ],
-            $this->list->toArray(prioritylist::EXTR_BOTH)
+            $this->list->toArray(PriorityList::EXTR_BOTH)
         );
     }
 

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use laminas\stdlib\priorityqueue;
+use Laminas\Stdlib\PriorityQueue;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -20,12 +20,12 @@ use function var_export;
  */
 class PriorityQueueTest extends TestCase
 {
-    /** @var priorityqueue */
+    /** @var PriorityQueue */
     protected $queue;
 
     protected function setUp(): void
     {
-        $this->queue = new priorityqueue();
+        $this->queue = new PriorityQueue();
         $this->queue->insert('foo', 3);
         $this->queue->insert('bar', 4);
         $this->queue->insert('baz', 2);
@@ -72,7 +72,7 @@ class PriorityQueueTest extends TestCase
             2,
             1,
         ];
-        $test     = $this->queue->toArray(priorityqueue::EXTR_PRIORITY);
+        $test     = $this->queue->toArray(PriorityQueue::EXTR_PRIORITY);
         self::assertSame($expected, $test, var_export($test, true));
     }
 
@@ -84,7 +84,7 @@ class PriorityQueueTest extends TestCase
             ['data' => 'baz', 'priority' => 2],
             ['data' => 'bat', 'priority' => 1],
         ];
-        $test     = $this->queue->toArray(priorityqueue::EXTR_BOTH);
+        $test     = $this->queue->toArray(PriorityQueue::EXTR_BOTH);
         self::assertSame($expected, $test, var_export($test, true));
     }
 
@@ -126,7 +126,7 @@ class PriorityQueueTest extends TestCase
         $foo       = new stdClass();
         $foo->name = 'bar';
 
-        $queue = new priorityqueue();
+        $queue = new PriorityQueue();
         $queue->insert($foo, 1);
         $queue->insert($foo, 2);
 
@@ -151,7 +151,7 @@ class PriorityQueueTest extends TestCase
 
     public function testQueueRevertsToInitialStateWhenEmpty(): void
     {
-        $queue     = new priorityqueue();
+        $queue     = new PriorityQueue();
         $testQueue = clone $queue; // store the default state
 
         $testQueue->insert('foo', 1);
@@ -168,7 +168,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testUpdatesCountAfterExtractingTopElement(): void
     {
-        $queue = new priorityqueue();
+        $queue = new PriorityQueue();
         $queue->insert('first');
         $queue->insert('second');
 
@@ -182,7 +182,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testTopValueNotFoundAfterExtractingTopElement(): void
     {
-        $queue = new priorityqueue();
+        $queue = new PriorityQueue();
         $queue->insert('first');
         $queue->insert('second');
 
@@ -196,7 +196,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testValueStillFoundAfterExtractingTopElementWhenItIsADuplicate(): void
     {
-        $queue = new priorityqueue();
+        $queue = new PriorityQueue();
         $queue->insert('first');
         $queue->insert('second');
         $queue->insert('first');

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use Laminas\Stdlib\PriorityQueue;
+use laminas\stdlib\priorityqueue;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -20,12 +20,12 @@ use function var_export;
  */
 class PriorityQueueTest extends TestCase
 {
-    /** @var PriorityQueue */
+    /** @var priorityqueue */
     protected $queue;
 
     protected function setUp(): void
     {
-        $this->queue = new PriorityQueue();
+        $this->queue = new priorityqueue();
         $this->queue->insert('foo', 3);
         $this->queue->insert('bar', 4);
         $this->queue->insert('baz', 2);
@@ -72,7 +72,7 @@ class PriorityQueueTest extends TestCase
             2,
             1,
         ];
-        $test     = $this->queue->toArray(PriorityQueue::EXTR_PRIORITY);
+        $test     = $this->queue->toArray(priorityqueue::EXTR_PRIORITY);
         self::assertSame($expected, $test, var_export($test, true));
     }
 
@@ -84,7 +84,7 @@ class PriorityQueueTest extends TestCase
             ['data' => 'baz', 'priority' => 2],
             ['data' => 'bat', 'priority' => 1],
         ];
-        $test     = $this->queue->toArray(PriorityQueue::EXTR_BOTH);
+        $test     = $this->queue->toArray(priorityqueue::EXTR_BOTH);
         self::assertSame($expected, $test, var_export($test, true));
     }
 
@@ -126,7 +126,7 @@ class PriorityQueueTest extends TestCase
         $foo       = new stdClass();
         $foo->name = 'bar';
 
-        $queue = new PriorityQueue();
+        $queue = new priorityqueue();
         $queue->insert($foo, 1);
         $queue->insert($foo, 2);
 
@@ -151,7 +151,7 @@ class PriorityQueueTest extends TestCase
 
     public function testQueueRevertsToInitialStateWhenEmpty(): void
     {
-        $queue     = new PriorityQueue();
+        $queue     = new priorityqueue();
         $testQueue = clone $queue; // store the default state
 
         $testQueue->insert('foo', 1);
@@ -168,7 +168,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testUpdatesCountAfterExtractingTopElement(): void
     {
-        $queue = new PriorityQueue();
+        $queue = new priorityqueue();
         $queue->insert('first');
         $queue->insert('second');
 
@@ -182,7 +182,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testTopValueNotFoundAfterExtractingTopElement(): void
     {
-        $queue = new PriorityQueue();
+        $queue = new priorityqueue();
         $queue->insert('first');
         $queue->insert('second');
 
@@ -196,7 +196,7 @@ class PriorityQueueTest extends TestCase
      */
     public function testValueStillFoundAfterExtractingTopElementWhenItIsADuplicate(): void
     {
-        $queue = new PriorityQueue();
+        $queue = new priorityqueue();
         $queue->insert('first');
         $queue->insert('second');
         $queue->insert('first');

--- a/test/SplQueueTest.php
+++ b/test/SplQueueTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use Laminas\Stdlib\SplQueue;
+use laminas\stdlib\splqueue;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -14,12 +14,12 @@ use function unserialize;
 
 class SplQueueTest extends TestCase
 {
-    /** @var SplQueue */
+    /** @var splqueue */
     protected $queue;
 
     protected function setUp(): void
     {
-        $this->queue = new SplQueue();
+        $this->queue = new splqueue();
         $this->queue->push('foo');
         $this->queue->push('bar');
         $this->queue->push('baz');

--- a/test/SplQueueTest.php
+++ b/test/SplQueueTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use laminas\stdlib\splqueue;
+use Laminas\Stdlib\SplQueue;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -14,12 +14,12 @@ use function unserialize;
 
 class SplQueueTest extends TestCase
 {
-    /** @var splqueue */
+    /** @var SplQueue */
     protected $queue;
 
     protected function setUp(): void
     {
-        $this->queue = new splqueue();
+        $this->queue = new SplQueue();
         $this->queue->push('foo');
         $this->queue->push('bar');
         $this->queue->push('baz');

--- a/test/SplStackTest.php
+++ b/test/SplStackTest.php
@@ -1,10 +1,10 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use laminas\stdlib\splstack;
+use Laminas\Stdlib\SplStack;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -18,12 +18,12 @@ use function var_export;
  */
 class SplStackTest extends TestCase
 {
-    /** @var splstack */
+    /** @var SplStack */
     protected $stack;
 
     protected function setUp(): void
     {
-        $this->stack = new splstack();
+        $this->stack = new SplStack();
         $this->stack->push('foo');
         $this->stack->push('bar');
         $this->stack->push('baz');

--- a/test/SplStackTest.php
+++ b/test/SplStackTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
-use Laminas\Stdlib\SplStack;
+use laminas\stdlib\splstack;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -18,12 +18,12 @@ use function var_export;
  */
 class SplStackTest extends TestCase
 {
-    /** @var SplStack */
+    /** @var splstack */
     protected $stack;
 
     protected function setUp(): void
     {
-        $this->stack = new SplStack();
+        $this->stack = new splstack();
         $this->stack->push('foo');
         $this->stack->push('bar');
         $this->stack->push('baz');

--- a/test/StringWrapper/CommonStringWrapperTest.php
+++ b/test/StringWrapper/CommonStringWrapperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 
@@ -169,48 +169,48 @@ abstract class CommonStringWrapperTest extends TestCase
      */
     public function wordWrapProvider(): array
     {
-        // @codingStandardsIgnoreStart
+        // phpcs:disable Generic.Files.LineLength.TooLong
         return [
             // Standard cut tests
-            'cut-single-line' => ['utf-8', 'äbüöcß', 2, ' ', true, 'äb üö cß'],
-            'cut-multi-line' => ['utf-8', 'äbüöc ß äbüöcß', 2, ' ', true, 'äb üö c ß äb üö cß'],
-            'cut-multi-line-short-words' => ['utf-8', 'Ä very long wöööööööööööörd.', 8, "\n", true, "Ä very\nlong\nwööööööö\nööööörd."],
+            'cut-single-line'                        => ['utf-8', 'äbüöcß', 2, ' ', true, 'äb üö cß'],
+            'cut-multi-line'                         => ['utf-8', 'äbüöc ß äbüöcß', 2, ' ', true, 'äb üö c ß äb üö cß'],
+            'cut-multi-line-short-words'             => ['utf-8', 'Ä very long wöööööööööööörd.', 8, "\n", true, "Ä very\nlong\nwööööööö\nööööörd."],
             'cut-multi-line-with-previous-new-lines' => ['utf-8', "Ä very\nlong wöööööööööööörd.", 8, "\n", false, "Ä very\nlong\nwöööööööööööörd."],
-            'long-break' => ['utf-8', "Ä very<br>long wöö<br>öööööööö<br>öörd.", 8, '<br>', false, "Ä very<br>long wöö<br>öööööööö<br>öörd."],
+            'long-break'                             => ['utf-8', "Ä very<br>long wöö<br>öööööööö<br>öörd.", 8, '<br>', false, "Ä very<br>long wöö<br>öööööööö<br>öörd."],
 
             // Alternative cut tests
-            'cut-beginning-single-space' => ['utf-8', ' äüöäöü', 3, ' ', true, ' äüö äöü'],
-            'cut-ending-single-space' => ['utf-8', 'äüöäöü ', 3, ' ', true, 'äüö äöü '],
+            'cut-beginning-single-space'                     => ['utf-8', ' äüöäöü', 3, ' ', true, ' äüö äöü'],
+            'cut-ending-single-space'                        => ['utf-8', 'äüöäöü ', 3, ' ', true, 'äüö äöü '],
             'cut-ending-single-space-with-non-space-divider' => ['utf-8', 'äöüäöü ', 3, '-', true, 'äöü-äöü-'],
-            'cut-ending-two-spaces' => ['utf-8', 'äüöäöü  ', 3, ' ', true, 'äüö äöü  '],
-            'no-cut-ending-single-space' => ['utf-8', '12345 ', 5, '-', false, '12345-'],
-            'no-cut-ending-two-spaces' => ['utf-8', '12345  ', 5, '-', false, '12345- '],
-            'cut-ending-three-spaces' => ['utf-8', 'äüöäöü  ', 3, ' ', true, 'äüö äöü  '],
-            'cut-ending-two-breaks' => ['utf-8', 'äüöäöü--', 3, '-', true, 'äüö-äöü--'],
-            'cut-tab' => ['utf-8', "äbü\töcß", 3, ' ', true, "äbü \töc ß"],
-            'cut-new-line-with-space' => ['utf-8', "äbü\nößt", 3, ' ', true, "äbü \nöß t"],
-            'cut-new-line-with-new-line' => ['utf-8', "äbü\nößte", 3, "\n", true, "äbü\nößt\ne"],
+            'cut-ending-two-spaces'                          => ['utf-8', 'äüöäöü  ', 3, ' ', true, 'äüö äöü  '],
+            'no-cut-ending-single-space'                     => ['utf-8', '12345 ', 5, '-', false, '12345-'],
+            'no-cut-ending-two-spaces'                       => ['utf-8', '12345  ', 5, '-', false, '12345- '],
+            'cut-ending-three-spaces'                        => ['utf-8', 'äüöäöü  ', 3, ' ', true, 'äüö äöü  '],
+            'cut-ending-two-breaks'                          => ['utf-8', 'äüöäöü--', 3, '-', true, 'äüö-äöü--'],
+            'cut-tab'                                        => ['utf-8', "äbü\töcß", 3, ' ', true, "äbü \töc ß"],
+            'cut-new-line-with-space'                        => ['utf-8', "äbü\nößt", 3, ' ', true, "äbü \nöß t"],
+            'cut-new-line-with-new-line'                     => ['utf-8', "äbü\nößte", 3, "\n", true, "äbü\nößt\ne"],
 
             // Break cut tests
-            'cut-break-before' => ['ascii', 'foobar-foofoofoo', 8, '-', true, 'foobar-foofoofo-o'],
-            'cut-break-with' => ['ascii', 'foobar-foobar', 6, '-', true, 'foobar-foobar'],
-            'cut-break-within' => ['ascii', 'foobar-foobar', 7, '-', true, 'foobar-foobar'],
+            'cut-break-before'     => ['ascii', 'foobar-foofoofoo', 8, '-', true, 'foobar-foofoofo-o'],
+            'cut-break-with'       => ['ascii', 'foobar-foobar', 6, '-', true, 'foobar-foobar'],
+            'cut-break-within'     => ['ascii', 'foobar-foobar', 7, '-', true, 'foobar-foobar'],
             'cut-break-within-end' => ['ascii', 'foobar-', 7, '-', true, 'foobar-'],
-            'cut-break-after' => ['ascii', 'foobar-foobar', 5, '-', true, 'fooba-r-fooba-r'],
+            'cut-break-after'      => ['ascii', 'foobar-foobar', 5, '-', true, 'fooba-r-fooba-r'],
 
             // Standard no-cut tests
             'no-cut-single-line' => ['utf-8', 'äbüöcß', 2, ' ', false, 'äbüöcß'],
-            'no-cut-multi-line' => ['utf-8', 'äbüöc ß äbüöcß', 2, "\n", false, "äbüöc\nß\näbüöcß"],
-            'no-cut-multi-word' => ['utf-8', 'äöü äöü äöü', 5, "\n", false, "äöü\näöü\näöü"],
+            'no-cut-multi-line'  => ['utf-8', 'äbüöc ß äbüöcß', 2, "\n", false, "äbüöc\nß\näbüöcß"],
+            'no-cut-multi-word'  => ['utf-8', 'äöü äöü äöü', 5, "\n", false, "äöü\näöü\näöü"],
 
             // Break no-cut tests
-            'no-cut-break-before' => ['ascii', 'foobar-foofoofoo', 8, '-', false, 'foobar-foofoofoo'],
-            'no-cut-break-with' => ['ascii', 'foobar-foobar', 6, '-', false, 'foobar-foobar'],
-            'no-cut-break-within' => ['ascii', 'foobar-foobar', 7, '-', false, 'foobar-foobar'],
+            'no-cut-break-before'     => ['ascii', 'foobar-foofoofoo', 8, '-', false, 'foobar-foofoofoo'],
+            'no-cut-break-with'       => ['ascii', 'foobar-foobar', 6, '-', false, 'foobar-foobar'],
+            'no-cut-break-within'     => ['ascii', 'foobar-foobar', 7, '-', false, 'foobar-foobar'],
             'no-cut-break-within-end' => ['ascii', 'foobar-', 7, '-', false, 'foobar-'],
-            'no-cut-break-after' => ['ascii', 'foobar-foobar', 5, '-', false, 'foobar-foobar'],
+            'no-cut-break-after'      => ['ascii', 'foobar-foobar', 5, '-', false, 'foobar-foobar'],
         ];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**

--- a/test/StringWrapper/MbStringTest.php
+++ b/test/StringWrapper/MbStringTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 

--- a/test/TestAsset/ArrayObjectIterator/LegacyImplementation.php
+++ b/test/TestAsset/ArrayObjectIterator/LegacyImplementation.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib\TestAsset\ArrayObjectIterator;
+
+use Iterator;
+
+use function current;
+use function is_array;
+use function key;
+use function next;
+use function reset;
+
+class LegacyImplementation implements Iterator
+{
+    /** @var array */
+    private $var = [];
+
+    /** @param array $array */
+    public function __construct($array)
+    {
+        if (is_array($array)) {
+            $this->var = $array;
+        }
+    }
+
+    /** @return void */
+    public function rewind()
+    {
+        reset($this->var);
+    }
+
+    /** @return mixed */
+    public function current()
+    {
+        return current($this->var);
+    }
+
+    /** @return int|string */
+    public function key()
+    {
+        return key($this->var);
+    }
+
+    /** @return mixed */
+    public function next()
+    {
+        return next($this->var);
+    }
+
+    /** @return bool */
+    public function valid()
+    {
+        $key = key($this->var);
+        return $key !== null && $key !== false;
+    }
+}

--- a/test/TestAsset/ArrayObjectIterator/PHP81Implementation.php
+++ b/test/TestAsset/ArrayObjectIterator/PHP81Implementation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace LaminasTest\Stdlib\TestAsset;
+namespace LaminasTest\Stdlib\TestAsset\ArrayObjectIterator;
 
 use Iterator;
 
@@ -12,7 +12,7 @@ use function key;
 use function next;
 use function reset;
 
-class ArrayObjectIterator implements Iterator
+class PHP81Implementation implements Iterator
 {
     /** @var array */
     private $var = [];
@@ -25,32 +25,28 @@ class ArrayObjectIterator implements Iterator
         }
     }
 
-    /** @return void */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->var);
     }
 
-    /** @return mixed */
-    public function current()
+    public function current(): mixed
     {
         return current($this->var);
     }
 
     /** @return int|string */
-    public function key()
+    public function key(): mixed
     {
         return key($this->var);
     }
 
-    /** @return mixed */
-    public function next()
+    public function next(): void
     {
-        return next($this->var);
+        next($this->var);
     }
 
-    /** @return bool */
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->var);
         return $key !== null && $key !== false;

--- a/test/TestAsset/ArrayObjectObjectCount/LegacyImplementation.php
+++ b/test/TestAsset/ArrayObjectObjectCount/LegacyImplementation.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace LaminasTest\Stdlib\TestAsset;
+namespace LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount;
 
 use Countable;
 
-class ArrayObjectObjectCount implements Countable
+class LegacyImplementation implements Countable
 {
     /** @return int */
     public function count()

--- a/test/TestAsset/ArrayObjectObjectCount/PHP81Implementation.php
+++ b/test/TestAsset/ArrayObjectObjectCount/PHP81Implementation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount;
+
+use Countable;
+
+class PHP81Implementation implements Countable
+{
+    public function count(): int
+    {
+        return 42;
+    }
+}

--- a/test/TestAsset/GuardedObject.php
+++ b/test/TestAsset/GuardedObject.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
 
 declare(strict_types=1);
 

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -8,18 +8,20 @@ use function class_alias;
 
 use const PHP_VERSION_ID;
 
-// LaminasTest\Stdlib\TestAsset\ArrayObjectIterator
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? TestAsset\ArrayObjectIterator\PHP81Implementation::class
-    : TestAsset\ArrayObjectIterator\LegacyImplementation::class,
-    TestAsset\ArrayObjectIterator::class
-);
+// PHP < 8.1
+if (PHP_VERSION_ID < 80100) {
+    // LaminasTest\Stdlib\TestAsset\ArrayObjectIterator
+    class_alias(TestAsset\ArrayObjectIterator\LegacyImplementation::class, TestAsset\ArrayObjectIterator::class);
 
-// LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount
-class_alias(
-    PHP_VERSION_ID >= 80100
-    ? TestAsset\ArrayObjectObjectCount\PHP81Implementation::class
-    : TestAsset\ArrayObjectObjectCount\LegacyImplementation::class,
-    TestAsset\ArrayObjectObjectCount::class
-);
+    // LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount
+    class_alias(TestAsset\ArrayObjectObjectCount\LegacyImplementation::class, TestAsset\ArrayObjectObjectCount::class);
+}
+
+// PHP 8.1+
+if (PHP_VERSION_ID >= 80100) {
+    // LaminasTest\Stdlib\TestAsset\ArrayObjectIterator
+    class_alias(TestAsset\ArrayObjectIterator\PHP81Implementation::class, TestAsset\ArrayObjectIterator::class);
+
+    // LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount
+    class_alias(TestAsset\ArrayObjectObjectCount\PHP81Implementation::class, TestAsset\ArrayObjectObjectCount::class);
+}

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,25 @@
+<?php // phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase.Invalid,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib;
+
+use function class_alias;
+
+use const PHP_VERSION_ID;
+
+// LaminasTest\Stdlib\TestAsset\ArrayObjectIterator
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? TestAsset\ArrayObjectIterator\PHP81Implementation::class
+    : TestAsset\ArrayObjectIterator\LegacyImplementation::class,
+    TestAsset\ArrayObjectIterator::class
+);
+
+// LaminasTest\Stdlib\TestAsset\ArrayObjectObjectCount
+class_alias(
+    PHP_VERSION_ID >= 80100
+    ? TestAsset\ArrayObjectObjectCount\PHP81Implementation::class
+    : TestAsset\ArrayObjectObjectCount\LegacyImplementation::class,
+    TestAsset\ArrayObjectObjectCount::class
+);


### PR DESCRIPTION
This silences the deprecated warnings in PHP 8.1:

- It creates polyfills for each of the `ArrayObject`, `FastPriorityQueue`, `Parameters`, `PriorityList`, `PriorityQueue`, `SplQueue`, and `SplStack` implementations. The new "legacy" implementations keep the same functionality as was present in previous versions, while the "PHP 8.1" implementations add typehints that are required in order to remove deprecation warnings under PHP 8.1 (PHP 8.1 deprecates the ability to define extensions of internal classes that change signatures in any way, even if they fulfill the contravariance/covariance rules.)
  - Autoloading rules alias the appropriate implementation to the original class name based on the PHP version in use.
- It adds `__unserialize()` and `__serialize()` implementations to all classes that previously implemented the `Serializable` interface. The `Serializable` implementations now consume these new methods to make them forwards compatible.
- Because of the polyfill implementations, a large number of code improvements were created to fix new issues flagged by Psalm due to the new class names. In most cases, these are adding type checking to ensure code will work correctly.

### BC concerns

The PHP 8.1 implementations add typehints to signatures where they did not previously exist. In each case, these are compatible with the previous implementation, but they _do_ pose breakage for anybody extending the classes and overriding the relevant methods. **However**, these would lead to deprecation warnings, and, in some cases, fatal errors under PHP 8.1.

Fixes #24
