### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e87e10e9a23ed70f23a4c921ba44f69",
+    "content-hash": "0ca66a7411f00dee3f24f2b162870c72",
     "packages": [],
     "packages-dev": [
         {
@@ -5109,7 +5109,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+<files psalm-version="4.9.3@4c262932602b9bbab5020863d1eb22d49de0dbf4">
   <file src="src/AbstractOptions.php">
     <DocblockTypeContradiction occurrences="1">
       <code>! is_array($options) &amp;&amp; ! $options instanceof Traversable</code>
@@ -31,35 +31,19 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>new $class($this-&gt;storage)</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="6">
-      <code>$ar['flag']</code>
-      <code>$ar['iteratorClass']</code>
-      <code>$ar['storage']</code>
-      <code>$v</code>
-      <code>$v</code>
-      <code>$v</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$function</code>
       <code>$function</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$ar['flag']</code>
-      <code>$ar['iteratorClass']</code>
-      <code>$ar['storage']</code>
-    </MixedArrayAccess>
     <MixedArrayOffset occurrences="4">
       <code>$this-&gt;storage[$key]</code>
       <code>$this-&gt;storage[$key]</code>
       <code>$this-&gt;storage[$key]</code>
       <code>$this-&gt;storage[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
-      <code>$ar</code>
-      <code>$k</code>
+    <MixedAssignment occurrences="2">
       <code>$ret</code>
       <code>$ret</code>
-      <code>$v</code>
     </MixedAssignment>
     <MoreSpecificReturnType occurrences="1">
       <code>Iterator</code>
@@ -316,11 +300,7 @@
     <MethodSignatureMismatch occurrences="1">
       <code>public function insert($datum, $priority)</code>
     </MethodSignatureMismatch>
-    <MixedArrayAccess occurrences="2">
-      <code>$item['data']</code>
-      <code>$item['priority']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$array[]</code>
       <code>$data[]</code>
       <code>$item</code>

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -455,12 +455,12 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
     }
 
-   /**
+    /**
      * Magic method used to rebuild an instance.
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         $this->protectedProperties = array_keys(get_object_vars($this));

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -9,20 +9,25 @@ use Countable;
 use Iterator;
 use IteratorAggregate;
 use Serializable;
+use UnexpectedValueException;
 
 use function array_keys;
 use function asort;
 use function class_exists;
 use function count;
+use function get_class;
 use function get_object_vars;
+use function gettype;
 use function in_array;
 use function is_array;
 use function is_callable;
 use function is_object;
+use function is_string;
 use function ksort;
 use function natcasesort;
 use function natsort;
 use function serialize;
+use function sprintf;
 use function strpos;
 use function uasort;
 use function uksort;
@@ -345,7 +350,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      */
     public function serialize()
     {
-        return serialize(get_object_vars($this));
+        return serialize($this->__serialize());
     }
 
     /**
@@ -429,30 +434,15 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      */
     public function unserialize($data)
     {
-        $ar                        = unserialize($data);
-        $this->protectedProperties = array_keys(get_object_vars($this));
-
-        $this->setFlags($ar['flag']);
-        $this->exchangeArray($ar['storage']);
-        $this->setIteratorClass($ar['iteratorClass']);
-
-        foreach ($ar as $k => $v) {
-            switch ($k) {
-                case 'flag':
-                    $this->setFlags($v);
-                    break;
-                case 'storage':
-                    $this->exchangeArray($v);
-                    break;
-                case 'iteratorClass':
-                    $this->setIteratorClass($v);
-                    break;
-                case 'protectedProperties':
-                    break;
-                default:
-                    $this->__set($k, $v);
-            }
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance; corrupt serialization data',
+                self::class
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
     /**
@@ -465,26 +455,43 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     {
         $this->protectedProperties = array_keys(get_object_vars($this));
 
-        $this->setFlags($data['flag']);
-        $this->exchangeArray($data['storage']);
-        $this->setIteratorClass($data['iteratorClass']);
-
         foreach ($data as $k => $v) {
             switch ($k) {
                 case 'flag':
-                    $this->setFlags($v);
+                    $this->setFlags((int) $v);
                     break;
+
                 case 'storage':
+                    if (! is_array($v) && ! is_object($v)) {
+                        throw new UnexpectedValueException(sprintf(
+                            'Cannot deserialize %s instance: corrupt storage data;'
+                            . ' expected array or object, received %s',
+                            self::class,
+                            gettype($v)
+                        ));
+                    }
+
                     $this->exchangeArray($v);
                     break;
+
                 case 'iteratorClass':
+                    if (! is_string($v)) {
+                        throw new UnexpectedValueException(sprintf(
+                            'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
+                            self::class,
+                            is_object($v) ? get_class($v) : gettype($v)
+                        ));
+                    }
+
                     $this->setIteratorClass($v);
                     break;
+
                 case 'protectedProperties':
                     break;
+
                 default:
                     $this->__set($k, $v);
             }
         }
-    }	
+    }
 }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -349,6 +349,16 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
      * Sets the behavior flags
      *
      * @param  int  $flags
@@ -444,4 +454,37 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
             }
         }
     }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        $this->protectedProperties = array_keys(get_object_vars($this));
+
+        $this->setFlags($data['flag']);
+        $this->exchangeArray($data['storage']);
+        $this->setIteratorClass($data['iteratorClass']);
+
+        foreach ($data as $k => $v) {
+            switch ($k) {
+                case 'flag':
+                    $this->setFlags($v);
+                    break;
+                case 'storage':
+                    $this->exchangeArray($v);
+                    break;
+                case 'iteratorClass':
+                    $this->setIteratorClass($v);
+                    break;
+                case 'protectedProperties':
+                    break;
+                default:
+                    $this->__set($k, $v);
+            }
+        }
+    }	
 }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Countable;
 use Iterator;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -185,6 +186,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->storage);
@@ -243,6 +245,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      *
      * @return Iterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $class = $this->iteratorClass;
@@ -296,6 +299,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param  mixed $key
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->storage[$key]);
@@ -307,6 +311,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param  mixed $key
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function &offsetGet($key)
     {
         $ret = null;
@@ -325,6 +330,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param  mixed $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->storage[$key] = $value;
@@ -336,6 +342,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param  mixed $key
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         if ($this->offsetExists($key)) {

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -6,6 +6,7 @@ namespace Laminas\Stdlib;
 
 use Countable;
 use Iterator;
+use ReturnTypeWillChange;
 use Serializable;
 use SplPriorityQueue as PhpSplPriorityQueue;
 use UnexpectedValueException;
@@ -87,6 +88,26 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * @var integer
      */
     protected $subIndex = 0;
+
+    public function __serialize(): array
+    {
+        $clone = clone $this;
+        $clone->setExtractFlags(self::EXTR_BOTH);
+
+        $data = [];
+        foreach ($clone as $item) {
+            $data[] = $item;
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $item) {
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
 
     /**
      * Insert an element in the queue with a specified priority
@@ -179,8 +200,9 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Get the total number of elements in the queue
      *
-     * @return integer
+     * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->count;
@@ -191,6 +213,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         switch ($this->extractFlag) {
@@ -209,8 +232,9 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Get the index of the current element in the queue
      *
-     * @return integer
+     * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
@@ -243,6 +267,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * Set the iterator pointer to the next element in the queue
      * without removing the previous element
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         if (false === next($this->values[$this->maxPriority])) {
@@ -258,8 +283,9 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Check if the current iterator is valid
      *
-     * @return boolean
+     * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->values[$this->maxPriority]);
@@ -268,6 +294,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Rewind the current iterator
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->subPriorities = $this->priorities;
@@ -299,15 +326,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     public function serialize()
     {
-        $clone = clone $this;
-        $clone->setExtractFlags(self::EXTR_BOTH);
-
-        $data = [];
-        foreach ($clone as $item) {
-            $data[] = $item;
-        }
-
-        return serialize($data);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -318,9 +337,15 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->insert($item['data'], $item['priority']);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance; corrupt serialization data',
+                self::class
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
     /**

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -8,15 +8,18 @@ use Countable;
 use Iterator;
 use Serializable;
 use SplPriorityQueue as PhpSplPriorityQueue;
+use UnexpectedValueException;
 
 use function current;
 use function in_array;
+use function is_array;
 use function is_int;
 use function key;
 use function max;
 use function next;
 use function reset;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 /**

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 use ArrayObject as PhpArrayObject;
+use ReturnTypeWillChange;
 
 use function http_build_query;
 use function parse_str;
@@ -79,6 +80,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * @param  string $name
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($name)
     {
         if ($this->offsetExists($name)) {

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -7,6 +7,7 @@ namespace Laminas\Stdlib;
 use Countable;
 use Exception;
 use Iterator;
+use ReturnTypeWillChange;
 
 use function array_map;
 use function current;
@@ -194,6 +195,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->sort();
@@ -203,6 +205,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->sorted || $this->sort();
@@ -214,6 +217,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $this->sorted || $this->sort();
@@ -223,6 +227,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $node = next($this->items);
@@ -233,6 +238,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current($this->items) !== false;
@@ -249,6 +255,7 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->count;

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -240,7 +240,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -7,10 +7,12 @@ namespace Laminas\Stdlib;
 use Countable;
 use IteratorAggregate;
 use Serializable;
+use UnexpectedValueException;
 
 use function array_map;
 use function count;
 use function get_class;
+use function is_array;
 use function serialize;
 use function sprintf;
 use function unserialize;
@@ -207,7 +209,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      */
     public function serialize()
     {
-        return serialize($this->items);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -230,17 +232,23 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->insert($item['data'], $item['priority']);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance; corrupt serialization data',
+                self::class
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -6,6 +6,7 @@ namespace Laminas\Stdlib;
 
 use Countable;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -132,6 +133,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
@@ -196,6 +198,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @return SplPriorityQueue
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $queue = $this->getQueue();

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -211,6 +211,16 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->items;
+    }
+
+    /**
      * Unserialize a string into a PriorityQueue object
      *
      * Serialization format is compatible with {@link Laminas\Stdlib\SplPriorityQueue}
@@ -221,6 +231,19 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -89,7 +89,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         foreach ($clone as $item) {
             $data[] = $item;
         }
-		return $data;
+        return $data;
     }
 	
     /**

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -76,6 +76,23 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $clone = clone $this;
+        $clone->setExtractFlags(self::EXTR_BOTH);
+
+        $data = [];
+        foreach ($clone as $item) {
+            $data[] = $item;
+        }
+		return $data;
+    }
+	
+    /**
      * Deserialize
      *
      * @param  string $data
@@ -85,6 +102,21 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
     {
         $this->serial = PHP_INT_MAX;
         foreach (unserialize($data) as $item) {
+            $this->serial--;
+            $this->insert($item['data'], $item['priority']);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        $this->serial = PHP_INT_MAX;
+        foreach ($data as $item) {
             $this->serial--;
             $this->insert($item['data'], $item['priority']);
         }

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -91,7 +91,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         }
         return $data;
     }
-	
+
     /**
      * Deserialize
      *
@@ -112,7 +112,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         $this->serial = PHP_INT_MAX;

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -107,7 +107,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
         }
     }
 
-   /**
+    /**
      * Magic method used to rebuild an instance.
      *
      * @param array $data Data array.

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -66,7 +66,7 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -36,6 +37,7 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function serialize()
     {
         return serialize($this->__serialize());
@@ -46,6 +48,7 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function __serialize()
     {
         return $this->toArray();
@@ -57,6 +60,7 @@ class SplQueue extends \SplQueue implements Serializable
      * @param  string $data
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function unserialize($data)
     {
         $toUnserialize = unserialize($data);
@@ -76,6 +80,7 @@ class SplQueue extends \SplQueue implements Serializable
     * @param array $data Data array.
     * @return void
     */
+    #[ReturnTypeWillChange]
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -39,6 +39,16 @@ class SplQueue extends \SplQueue implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Unserialize
      *
      * @param  string $data
@@ -47,6 +57,19 @@ class SplQueue extends \SplQueue implements Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->push($item);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->push($item);
         }
     }

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 use Serializable;
+use UnexpectedValueException;
 
+use function is_array;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 /**
@@ -35,7 +38,7 @@ class SplQueue extends \SplQueue implements Serializable
      */
     public function serialize()
     {
-        return serialize($this->toArray());
+        return serialize($this->__serialize());
     }
 
     /**
@@ -56,17 +59,23 @@ class SplQueue extends \SplQueue implements Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->push($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance; corrupt serialization data',
+                self::class
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -66,7 +66,7 @@ class SplStack extends \SplStack implements Serializable
      *
      * @param array $data Data array.
      * @return void
-     */	
+     */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -36,6 +37,7 @@ class SplStack extends \SplStack implements Serializable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function serialize()
     {
         return serialize($this->__serialize());
@@ -46,6 +48,7 @@ class SplStack extends \SplStack implements Serializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function __serialize()
     {
         return $this->toArray();
@@ -57,6 +60,7 @@ class SplStack extends \SplStack implements Serializable
      * @param  string $data
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function unserialize($data)
     {
         $toUnserialize = unserialize($data);
@@ -76,6 +80,7 @@ class SplStack extends \SplStack implements Serializable
     * @param array $data Data array.
     * @return void
     */
+    #[ReturnTypeWillChange]
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 use Serializable;
+use UnexpectedValueException;
 
+use function is_array;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 /**
@@ -35,7 +38,7 @@ class SplStack extends \SplStack implements Serializable
      */
     public function serialize()
     {
-        return serialize($this->toArray());
+        return serialize($this->__serialize());
     }
 
     /**
@@ -56,17 +59,23 @@ class SplStack extends \SplStack implements Serializable
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
-            $this->unshift($item);
+        $toUnserialize = unserialize($data);
+        if (! is_array($toUnserialize)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance; corrupt serialization data',
+                self::class
+            ));
         }
+
+        $this->__unserialize($toUnserialize);
     }
 
    /**
-     * Magic method used to rebuild an instance.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
+    * Magic method used to rebuild an instance.
+    *
+    * @param array $data Data array.
+    * @return void
+    */
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -39,6 +39,16 @@ class SplStack extends \SplStack implements Serializable
     }
 
     /**
+     * Magic method used for serializing of an instance.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Unserialize
      *
      * @param  string $data
@@ -47,6 +57,19 @@ class SplStack extends \SplStack implements Serializable
     public function unserialize($data)
     {
         foreach (unserialize($data) as $item) {
+            $this->unshift($item);
+        }
+    }
+
+   /**
+     * Magic method used to rebuild an instance.
+     *
+     * @param array $data Data array.
+     * @return void
+     */	
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->unshift($item);
         }
     }

--- a/test/TestAsset/ArrayObjectIterator.php
+++ b/test/TestAsset/ArrayObjectIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Stdlib\TestAsset;
 
 use Iterator;
+use ReturnTypeWillChange;
 
 use function current;
 use function is_array;
@@ -26,30 +27,35 @@ class ArrayObjectIterator implements Iterator
     }
 
     /** @return void */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->var);
     }
 
     /** @return mixed */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->var);
     }
 
     /** @return int|string */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->var);
     }
 
     /** @return mixed */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->var);
     }
 
     /** @return bool */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $key = key($this->var);

--- a/test/TestAsset/ArrayObjectObjectCount.php
+++ b/test/TestAsset/ArrayObjectObjectCount.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace LaminasTest\Stdlib\TestAsset;
 
 use Countable;
+use ReturnTypeWillChange;
 
 class ArrayObjectObjectCount implements Countable
 {
-    /** @return int */
+    /**
+     * @return int
+     */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 42;


### PR DESCRIPTION
This patch builds on #34, but uses a different direction for providing full compatibility with PHP 8.1.

Instead of using polyfills, we can use the `#[ReturnValueWillChange]` attribute on signatures that extend/implement internal class/interface methods (along with importing the `ReturnValueWillChange` virtual attribute).  Recent updates to phpcs allow this to work, and Psalm discovers the annotation and considers it when determining if a signature change poses a compatibility problem.

Additionally, this patch:

- adds PHP 8.1 to the PHP constraint
- refactors the patch in #34 to proxy to the `__unserialize()`/`__serialize()` methods from the `unserialize()`/`serialize()` methods

Fixes #24
