### PR TITLE
Fix `Iconv::substr` nullable

### DIFF
--- a/src/StringWrapper/Iconv.php
+++ b/src/StringWrapper/Iconv.php
@@ -244,7 +244,7 @@ class Iconv extends AbstractStringWrapper
      */
     public function substr($str, $offset = 0, $length = null)
     {
-        return iconv_substr($str, $offset, $length, $this->getEncoding());
+        return iconv_substr($str, $offset, $length ?: iconv_strlen($str, $this->getEncoding()), $this->getEncoding());
     }
 
     /**


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fix `iconv_substr()` expects parameter 3 to be int

PHP: 7.4.25


```php
$utf8StrWrapper = \Laminas\Stdlib\StringUtils::getWrapper('UTF-8');
$utf8StrWrapper->substr('test');
// TypeError: iconv_substr() expects parameter 3 to be int, null given 

```
