### PR TITLE
Fix `Iconv::substr()` raising warnings when `null` is given as length

### DIFF
--- a/src/StringWrapper/Iconv.php
+++ b/src/StringWrapper/Iconv.php
@@ -244,7 +244,12 @@ class Iconv extends AbstractStringWrapper
      */
     public function substr($str, $offset = 0, $length = null)
     {
-        return iconv_substr($str, $offset, $length, $this->getEncoding());
+        return iconv_substr(
+            $str,
+            $offset,
+            $length === null ? iconv_strlen($str, $this->getEncoding()) : $length,
+            $this->getEncoding()
+        );
     }
 
     /**

--- a/src/StringWrapper/Iconv.php
+++ b/src/StringWrapper/Iconv.php
@@ -6,6 +6,7 @@ namespace Laminas\Stdlib\StringWrapper;
 
 use Laminas\Stdlib\Exception;
 
+use function assert;
 use function extension_loaded;
 use function iconv;
 use function iconv_strlen;
@@ -244,12 +245,10 @@ class Iconv extends AbstractStringWrapper
      */
     public function substr($str, $offset = 0, $length = null)
     {
-        return iconv_substr(
-            $str,
-            $offset,
-            $length === null ? iconv_strlen($str, $this->getEncoding()) : $length,
-            $this->getEncoding()
-        );
+        $length = $length ?? $this->strlen($str);
+        assert($length !== false);
+
+        return iconv_substr($str, $offset, $length, $this->getEncoding());
     }
 
     /**
@@ -262,7 +261,10 @@ class Iconv extends AbstractStringWrapper
      */
     public function strpos($haystack, $needle, $offset = 0)
     {
-        return iconv_strpos($haystack, $needle, $offset, $this->getEncoding());
+        $encoding = $this->getEncoding();
+        assert($encoding !== null);
+
+        return iconv_strpos($haystack, $needle, $offset, $encoding);
     }
 
     /**

--- a/test/StringWrapper/CommonStringWrapperTest.php
+++ b/test/StringWrapper/CommonStringWrapperTest.php
@@ -57,7 +57,7 @@ abstract class CommonStringWrapperTest extends TestCase
      *     0: string,
      *     1: string,
      *     2: int,
-     *     3: int,
+     *     3: ?int,
      *     4: string
      * }>
      */
@@ -65,6 +65,7 @@ abstract class CommonStringWrapperTest extends TestCase
     {
         return [
             ['ascii', 'abcdefghijkl', 1, 5, 'bcdef'],
+            ['utf-8', 'abcdefghijkl', 1, null, 'bcdefghijkl'],
             ['utf-8', 'abcdefghijkl', 1, 5, 'bcdef'],
             ['utf-8', 'äöüß',         1, 2, 'öü'],
         ];
@@ -73,7 +74,7 @@ abstract class CommonStringWrapperTest extends TestCase
     /**
      * @dataProvider substrProvider
      */
-    public function testSubstr(string $encoding, string $str, int $offset, int $length, string $expected): void
+    public function testSubstr(string $encoding, string $str, int $offset, ?int $length, string $expected): void
     {
         $wrapper = $this->getWrapper($encoding);
         if (! $wrapper) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fix `iconv_substr()` expects parameter 3 to be int

PHP: 7.4.25


```php
$utf8StrWrapper = \Laminas\Stdlib\StringUtils::getWrapper('UTF-8');
$utf8StrWrapper->substr('test');
// TypeError: iconv_substr() expects parameter 3 to be int, null given 

```
