### PR TITLE
[3.6] Regression: ArrayObject with protected ARRAY_AS_PROPS cannot be serialized anymore

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -41,9 +41,11 @@
       <code>$this-&gt;storage[$key]</code>
       <code>$this-&gt;storage[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="4">
+      <code>$flag</code>
       <code>$ret</code>
       <code>$ret</code>
+      <code>$v</code>
     </MixedAssignment>
     <MoreSpecificReturnType occurrences="1">
       <code>Iterator</code>
@@ -58,6 +60,14 @@
       <code>is_callable($function)</code>
       <code>is_callable($function)</code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedAttributeClass occurrences="6">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/ArrayUtils.php">
     <DocblockTypeContradiction occurrences="1">
@@ -158,6 +168,14 @@
       <code>$this-&gt;values</code>
       <code>$this-&gt;values</code>
     </PossiblyNullArrayOffset>
+    <UndefinedAttributeClass occurrences="6">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/Glob.php">
     <InvalidOperand occurrences="2">
@@ -205,6 +223,9 @@
     <MixedAssignment occurrences="1">
       <code>$this[$name]</code>
     </MixedAssignment>
+    <UndefinedAttributeClass occurrences="1">
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/PriorityList.php">
     <InvalidReturnStatement occurrences="1">
@@ -223,6 +244,14 @@
       <code>(int) $priority</code>
       <code>(int) $priority</code>
     </RedundantCastGivenDocblockType>
+    <UndefinedAttributeClass occurrences="6">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/PriorityQueue.php">
     <DocblockTypeContradiction occurrences="1">
@@ -292,6 +321,10 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>null !== $this-&gt;queue</code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedAttributeClass occurrences="2">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/SplPriorityQueue.php">
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -305,7 +338,6 @@
       <code>$data[]</code>
       <code>$item</code>
       <code>$item</code>
-      <code>$item</code>
     </MixedAssignment>
   </file>
   <file src="src/SplQueue.php">
@@ -314,6 +346,12 @@
       <code>$item</code>
       <code>$item</code>
     </MixedAssignment>
+    <UndefinedAttributeClass occurrences="4">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/SplStack.php">
     <MixedAssignment occurrences="3">
@@ -321,6 +359,12 @@
       <code>$item</code>
       <code>$item</code>
     </MixedAssignment>
+    <UndefinedAttributeClass occurrences="4">
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+      <code>ReturnTypeWillChange</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/StringUtils.php">
     <DocblockTypeContradiction occurrences="2">
@@ -377,9 +421,7 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/StringWrapper/Iconv.php">
-    <PossiblyNullArgument occurrences="4">
-      <code>$length</code>
-      <code>$this-&gt;getEncoding()</code>
+    <PossiblyNullArgument occurrences="2">
       <code>$this-&gt;getEncoding()</code>
       <code>$this-&gt;getEncoding()</code>
     </PossiblyNullArgument>
@@ -424,6 +466,12 @@
       <code>$ar['foo']['bar']</code>
       <code>$ar['foo']['bar']</code>
     </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$unserialized</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>isImmutable</code>
+    </MixedMethodCall>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertSame</code>
     </RedundantConditionGivenDocblockType>
@@ -499,6 +547,20 @@
       <code>$this-&gt;helper</code>
       <code>$this-&gt;helper</code>
     </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/CustomArrayObject.php">
+    <MissingPropertyType occurrences="1">
+      <code>$isImmutable</code>
+    </MissingPropertyType>
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;isImmutable</code>
+    </MixedReturnStatement>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CustomArrayObject</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="test/ErrorHandlerTest.php">
     <ArgumentTypeCoercion occurrences="3">

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -16,7 +16,6 @@ use function array_keys;
 use function asort;
 use function class_exists;
 use function count;
-use function get_class;
 use function get_object_vars;
 use function gettype;
 use function in_array;
@@ -92,7 +91,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new Exception\InvalidArgumentException("$key is a protected property, use a different key");
         }
 
         return isset($this->$key);
@@ -113,7 +112,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new Exception\InvalidArgumentException("$key is a protected property, use a different key");
         }
 
         $this->$key = $value;
@@ -133,7 +132,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new Exception\InvalidArgumentException("$key is a protected property, use a different key");
         }
 
         unset($this->$key);
@@ -154,7 +153,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
         }
 
         if (in_array($key, $this->protectedProperties, true)) {
-            throw new Exception\InvalidArgumentException('$key is a protected property, use a different key');
+            throw new Exception\InvalidArgumentException("$key is a protected property, use a different key");
         }
 
         return $this->$key;
@@ -462,43 +461,37 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     {
         $this->protectedProperties = array_keys(get_object_vars($this));
 
+        $flag = $data['flag'];
+        unset($data['flag']);
+        $this->setFlags((int) $flag);
+
+        $storage = $data['storage'];
+        unset($data['storage']);
+        if (! is_array($storage) && ! is_object($storage)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance: corrupt storage data;'
+                . ' expected array or object, received %s',
+                self::class,
+                gettype($storage)
+            ));
+        }
+        $this->exchangeArray($storage);
+
+        $iteratorClass = $data['iteratorClass'];
+        unset($data['iteratorClass']);
+        if (! is_string($iteratorClass)) {
+            throw new UnexpectedValueException(sprintf(
+                'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
+                self::class,
+                is_object($iteratorClass) ? get_class($iteratorClass) : gettype($iteratorClass)
+            ));
+        }
+        $this->setIteratorClass($iteratorClass);
+
+        unset($data['protectedProperties']);
+
         foreach ($data as $k => $v) {
-            switch ($k) {
-                case 'flag':
-                    $this->setFlags((int) $v);
-                    break;
-
-                case 'storage':
-                    if (! is_array($v) && ! is_object($v)) {
-                        throw new UnexpectedValueException(sprintf(
-                            'Cannot deserialize %s instance: corrupt storage data;'
-                            . ' expected array or object, received %s',
-                            self::class,
-                            gettype($v)
-                        ));
-                    }
-
-                    $this->exchangeArray($v);
-                    break;
-
-                case 'iteratorClass':
-                    if (! is_string($v)) {
-                        throw new UnexpectedValueException(sprintf(
-                            'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
-                            self::class,
-                            is_object($v) ? get_class($v) : gettype($v)
-                        ));
-                    }
-
-                    $this->setIteratorClass($v);
-                    break;
-
-                case 'protectedProperties':
-                    break;
-
-                default:
-                    $this->__set($k, $v);
-            }
+            $this->__set($k, $v);
         }
     }
 }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -462,35 +462,39 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     {
         $this->protectedProperties = array_keys(get_object_vars($this));
 
-        $flag = $data['flag'];
-        unset($data['flag']);
-        $this->setFlags((int) $flag);
-
-        $storage = $data['storage'];
-        unset($data['storage']);
-        if (! is_array($storage) && ! is_object($storage)) {
-            throw new UnexpectedValueException(sprintf(
-                'Cannot deserialize %s instance: corrupt storage data;'
-                . ' expected array or object, received %s',
-                self::class,
-                gettype($storage)
-            ));
+        // Unserialize protected internal properties first
+        if (array_key_exists('flag', $data)) {
+            $this->setFlags((int) $data['flag']);
+            unset($data['flag']);
         }
-        $this->exchangeArray($storage);
 
-        $iteratorClass = $data['iteratorClass'];
-        unset($data['iteratorClass']);
-        if (! is_string($iteratorClass)) {
-            throw new UnexpectedValueException(sprintf(
-                'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
-                self::class,
-                is_object($iteratorClass) ? get_class($iteratorClass) : gettype($iteratorClass)
-            ));
+        if (array_key_exists('storage', $data)) {
+            if (! is_array($data['storage']) && ! is_object($data['storage'])) {
+                throw new UnexpectedValueException(sprintf(
+                    'Cannot deserialize %s instance: corrupt storage data; expected array or object, received %s',
+                    self::class,
+                    gettype($data['storage'])
+                ));
+            }
+            $this->exchangeArray($data['storage']);
+            unset($data['storage']);
         }
-        $this->setIteratorClass($iteratorClass);
+
+        if (array_key_exists('iteratorClass', $data) {
+            if (! is_string($data['iteratorClass'])) {
+                throw new UnexpectedValueException(sprintf(
+                    'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
+                    self::class,
+                    is_object($data['iteratorClass']) ? get_class($data['iteratorClass']) : gettype($data['iteratorClass'])
+                ));
+            }
+            $this->setIteratorClass($data['iteratorClass']);
+            unset($data['iteratorClass']);
+        }
 
         unset($data['protectedProperties']);
 
+        // Unserialize array keys after resolving protected properties to ensure configuration is used.
         foreach ($data as $k => $v) {
             $this->__set($k, $v);
         }

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -486,7 +486,9 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                 throw new UnexpectedValueException(sprintf(
                     'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',
                     self::class,
-                    is_object($data['iteratorClass']) ? get_class($data['iteratorClass']) : gettype($data['iteratorClass'])
+                    is_object($data['iteratorClass'])
+                        ? get_class($data['iteratorClass'])
+                        : gettype($data['iteratorClass'])
                 ));
             }
             $this->setIteratorClass($data['iteratorClass']);

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -16,6 +16,7 @@ use function array_keys;
 use function asort;
 use function class_exists;
 use function count;
+use function get_class;
 use function get_object_vars;
 use function gettype;
 use function in_array;

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -12,6 +12,7 @@ use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
+use function array_key_exists;
 use function array_keys;
 use function asort;
 use function class_exists;
@@ -480,7 +481,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
             unset($data['storage']);
         }
 
-        if (array_key_exists('iteratorClass', $data) {
+        if (array_key_exists('iteratorClass', $data)) {
             if (! is_string($data['iteratorClass'])) {
                 throw new UnexpectedValueException(sprintf(
                     'Cannot deserialize %s instance: invalid iteratorClass; expected string, received %s',

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -401,4 +401,15 @@ class ArrayObjectTest extends TestCase
 
         self::assertEquals($ar, unserialize(serialize($ar)));
     }
+
+    public function testSerializationRestoresProtectedProperties(): void
+    {
+        $ar = new CustomArrayObject([], ArrayObject::ARRAY_AS_PROPS);
+        self::assertTrue($ar->isImmutable());
+
+        $serialized   = serialize($ar);
+        $unserialized = unserialize($serialized);
+
+        self::assertTrue($unserialized->isImmutable());
+    }
 }

--- a/test/CustomArrayObject.php
+++ b/test/CustomArrayObject.php
@@ -8,7 +8,7 @@ use Laminas\Stdlib\ArrayObject;
 
 final class CustomArrayObject extends ArrayObject
 {
-    protected bool $isImmutable = true;
+    protected $isImmutable = true;
 
     public function isImmutable(): bool
     {

--- a/test/CustomArrayObject.php
+++ b/test/CustomArrayObject.php
@@ -8,6 +8,7 @@ use Laminas\Stdlib\ArrayObject;
 
 final class CustomArrayObject extends ArrayObject
 {
+    /** @var bool */
     protected $isImmutable = true;
 
     public function isImmutable(): bool

--- a/test/CustomArrayObject.php
+++ b/test/CustomArrayObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib;
+
+use Laminas\Stdlib\ArrayObject;
+
+final class CustomArrayObject extends ArrayObject
+{
+    protected bool $isImmutable = true;
+
+    public function isImmutable(): bool
+    {
+        return $this->isImmutable;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | yes/no
| QA            | yes/no

### Description

In our app we serialize `Laminas\Session\Storage\ArrayStorage` objects as defined in its package:
https://github.com/laminas/laminas-session/blob/2.12.0/src/Storage/ArrayStorage.php
Which uses `ArrayObject::ARRAY_AS_PROPS` alongside a protected property `$isImmutable`.

Such serialization broke after https://github.com/laminas/laminas-stdlib/pull/35 has been released in `3.6` minor.

The proposed test indeed passes on `3.5.x` branch.

~~I hope to find a fix soon, in the meantime I'd like to know if such BC Break was intended or not, ping @weierophinney~~

Surely a BC Break that deserves a bugfix release, imho.