### PR TITLE
Fix #18 call `->toArray()` on `Traversable` instances given to `ArrayUtils::iteratorToArray()` only for instances which are **not** `Iterator` implementations

### DIFF
--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+use Iterator;
 use Laminas\Stdlib\ArrayUtils\MergeRemoveKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 use Traversable;
@@ -240,7 +241,11 @@ abstract class ArrayUtils
             return iterator_to_array($iterator);
         }
 
-        if (is_object($iterator) && method_exists($iterator, 'toArray')) {
+        if (
+            is_object($iterator)
+            && ! $iterator instanceof Iterator
+            && method_exists($iterator, 'toArray')
+        ) {
             return $iterator->toArray();
         }
 

--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -11,6 +11,7 @@ use Laminas\Stdlib\ArrayUtils\MergeReplaceKey;
 use Laminas\Stdlib\ArrayUtils\MergeReplaceKeyInterface;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
 use Laminas\Stdlib\Parameters;
+use LaminasTest\Stdlib\TestAsset\IteratorWithToArrayMethod;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Traversable;
@@ -578,5 +579,31 @@ class ArrayUtilsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         ArrayUtils::filter([], "INVALID");
+    }
+
+    /**
+     * @link https://github.com/laminas/laminas-stdlib/issues/18
+     */
+    public function testIteratorToArrayWithIteratorHavingMethodToArrayAndRecursiveIsFalse()
+    {
+        $arrayB    = [
+            'foo' => 'bar',
+        ];
+        $iteratorB = new IteratorWithToArrayMethod($arrayB);
+
+        $arrayA   = [
+            'iteratorB' => $iteratorB,
+        ];
+        $iterator = new IteratorWithToArrayMethod($arrayA);
+
+        $result = ArrayUtils::iteratorToArray($iterator, true);
+
+        $expectedResult = [
+            'iteratorB' => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $this->assertEquals($expectedResult, $result);
     }
 }

--- a/test/ArrayUtilsTest.php
+++ b/test/ArrayUtilsTest.php
@@ -584,7 +584,7 @@ class ArrayUtilsTest extends TestCase
     /**
      * @link https://github.com/laminas/laminas-stdlib/issues/18
      */
-    public function testIteratorToArrayWithIteratorHavingMethodToArrayAndRecursiveIsFalse()
+    public function testIteratorToArrayWithIteratorHavingMethodToArrayAndRecursiveIsFalse(): void
     {
         $arrayB    = [
             'foo' => 'bar',

--- a/test/TestAsset/IteratorWithToArrayMethod.php
+++ b/test/TestAsset/IteratorWithToArrayMethod.php
@@ -8,20 +8,18 @@ use Iterator;
 use ReturnTypeWillChange;
 
 use function current;
-use function is_array;
 use function key;
 use function next;
 use function reset;
 
 class IteratorWithToArrayMethod implements Iterator
 {
-    private array $elements = [];
+    /** @var array */
+    private $elements = [];
 
     public function __construct(array $elements)
     {
-        if (is_array($elements)) {
-            $this->elements = $elements;
-        }
+        $this->elements = $elements;
     }
 
     /** @return void */

--- a/test/TestAsset/IteratorWithToArrayMethod.php
+++ b/test/TestAsset/IteratorWithToArrayMethod.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib\TestAsset;
+
+use Iterator;
+use ReturnTypeWillChange;
+
+use function current;
+use function is_array;
+use function key;
+use function next;
+use function reset;
+
+class IteratorWithToArrayMethod implements Iterator
+{
+    private array $elements = [];
+
+    public function __construct(array $elements)
+    {
+        if (is_array($elements)) {
+            $this->elements = $elements;
+        }
+    }
+
+    /** @return void */
+    #[ReturnTypeWillChange]
+    public function rewind()
+    {
+        reset($this->elements);
+    }
+
+    /** @return mixed */
+    #[ReturnTypeWillChange]
+    public function current()
+    {
+        return current($this->elements);
+    }
+
+    /** @return int|string */
+    #[ReturnTypeWillChange]
+    public function key()
+    {
+        return key($this->elements);
+    }
+
+    /** @return mixed */
+    #[ReturnTypeWillChange]
+    public function next()
+    {
+        return next($this->elements);
+    }
+
+    /** @return bool */
+    #[ReturnTypeWillChange]
+    public function valid()
+    {
+        $key = key($this->elements);
+        return $key !== null && $key !== false;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'data from to array' => 'not good',
+        ];
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Fix of the issue #18 (ArrayUtils::iteratorToArray() different behaviour when recursive is false)

- Add unit test to reproduce and fix the bug

No when we use `ArrayUtils::iteratorToArray` with recursive = true
  - if traversable is an iterator we don't use the method toArray to get the data
  
A new test is added in the class `ArrayUtilsTest` under the method `testIteratorToArrayWithIteratorHavingMethodToArrayAndRecursiveIsFalse`

Fixes #18