### PR TITLE
Fix wrong negation in `Glob::glob()` introduced with 3.6.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
         id: matrix
         uses: laminas/laminas-ci-matrix-action@v1
 
-  qa:
+  qa-ubuntu:
     name: QA Checks
     needs: [matrix]
     runs-on: ${{ matrix.operatingSystem }}
@@ -31,3 +31,31 @@ jobs:
         uses: laminas/laminas-continuous-integration-action@v1
         with:
           job: ${{ matrix.job }}
+
+  qa-alpine:
+    name: QA Checks (PHPUnit on PHP 8.1 with Alpine Linux)
+    runs-on: ubuntu-latest
+    container:
+      image: php:8.1-alpine
+    steps:
+      - name: Show Alpine and PHP versions
+        run: |
+          cat /etc/os-release
+          php -v
+      - name: Install packages and PHP extensions
+        run: |
+          apk add git oniguruma-dev libxml2-dev
+          docker-php-ext-install mbstring
+          docker-php-ext-install xml
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install composer
+        run: |
+          php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+          php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+          php composer-setup.php
+          php -r "unlink('composer-setup.php');"
+      - name: Install latest dependencies
+        run: php composer.phar update --ignore-platform-req=php
+      - name: PHPUnit
+        run: ./vendor/bin/phpunit

--- a/src/Glob.php
+++ b/src/Glob.php
@@ -109,7 +109,7 @@ abstract class Glob
      */
     protected static function fallbackGlob($pattern, $flags)
     {
-        if (self::flagsIsEqualTo($flags, self::GLOB_BRACE)) {
+        if (! self::flagsIsEqualTo($flags, self::GLOB_BRACE)) {
             return static::systemGlob($pattern, $flags);
         }
 

--- a/test/StringWrapper/IconvTest.php
+++ b/test/StringWrapper/IconvTest.php
@@ -10,6 +10,10 @@ use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
 
 use function array_shift;
 use function extension_loaded;
+use function file_exists;
+use function file_get_contents;
+use function is_readable;
+use function stripos;
 
 class IconvTest extends CommonStringWrapperTest
 {
@@ -21,6 +25,19 @@ class IconvTest extends CommonStringWrapperTest
                 $this->fail('Missing expected Laminas\Stdlib\Exception\ExtensionNotLoadedException');
             } catch (Exception\ExtensionNotLoadedException $e) {
                 $this->markTestSkipped('Missing ext/iconv');
+            }
+        }
+
+        /**
+         * ext-iconv is not properly supported on Alpine Linux, hence, we skip the tests for now
+         *
+         * @see https://github.com/nunomaduro/phpinsights/issues/43
+         * @see https://github.com/docker-library/php/issues/240#issuecomment-353678474
+         */
+        if (file_exists('/etc/os-release') && is_readable('/etc/os-release')) {
+            $osRelease = file_get_contents('/etc/os-release');
+            if (stripos($osRelease, 'Alpine Linux') !== false) {
+                $this->markTestSkipped('iconv not properly supported on Alpine Linux');
             }
         }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Summary

This PR fixes #45.

### Description

Currently, all CI actions all executed using Ubuntu (latest). In [Glob.php](https://github.com/laminas/laminas-stdlib/blob/3.6.x/src/Glob.php) there is a distinction of cases if the current distribution supports `GLOB_BRACE` or not. If it does `systemGlob()` is used, otherwise `fallbackGlob()` is used. 

Now, `fallbackGlob()` just handles `GLOB_BRACE` and otherwise relies on `systemGlob()`. If there is an error like the one introduced in #43, then it can happen that such error is overlooked, because the underlying distribution (Ubuntu) supports `GLOB_BRACE`. Consequently, CI actions should not only be executed on Ubuntu, but also on a distribution not supporting `GLOB_BRACE`, like Alpine linux.

This PR adds a CI action running on Alpine Linux. PHPUnit on Alpine Linux brings 4 errors and 1 failure  ([see output](https://github.com/laminas/laminas-stdlib/runs/4658732987?check_suite_focus=true)):

```
There were 4 errors:

1) LaminasTest\Stdlib\StringWrapper\IconvTest::testConvert with data set #1 ('ascii', 'utf-8', 'abc', 'abc')
iconv(): Wrong encoding, conversion from "ASCII" to "UTF-8//IGNORE" is not allowed

/__w/laminas-stdlib/laminas-stdlib/src/StringWrapper/Iconv.php:300
/__w/laminas-stdlib/laminas-stdlib/test/StringWrapper/CommonStringWrapperTest.php:153
/__w/laminas-stdlib/laminas-stdlib/vendor/phpunit/phpunit/phpunit:61

2) LaminasTest\Stdlib\StringWrapper\IconvTest::testConvert with data set #2 ('utf-8', 'ascii', 'abc', 'abc')
iconv(): Wrong encoding, conversion from "UTF-8" to "ASCII//IGNORE" is not allowed

/__w/laminas-stdlib/laminas-stdlib/src/StringWrapper/Iconv.php:300
/__w/laminas-stdlib/laminas-stdlib/test/StringWrapper/CommonStringWrapperTest.php:153
/__w/laminas-stdlib/laminas-stdlib/vendor/phpunit/phpunit/phpunit:61

3) LaminasTest\Stdlib\StringWrapper\IconvTest::testConvert with data set #3 ('utf-8', 'iso-8859-15', '€', '�')
iconv(): Wrong encoding, conversion from "UTF-8" to "ISO-8859-15//IGNORE" is not allowed

/__w/laminas-stdlib/laminas-stdlib/src/StringWrapper/Iconv.php:300
/__w/laminas-stdlib/laminas-stdlib/test/StringWrapper/CommonStringWrapperTest.php:153
/__w/laminas-stdlib/laminas-stdlib/vendor/phpunit/phpunit/phpunit:61

4) LaminasTest\Stdlib\StringWrapper\IconvTest::testConvert with data set #4 ('utf-8', 'iso-8859-16', '€', '�')
iconv(): Wrong encoding, conversion from "UTF-8" to "ISO-8859-16//IGNORE" is not allowed

/__w/laminas-stdlib/laminas-stdlib/src/StringWrapper/Iconv.php:300
/__w/laminas-stdlib/laminas-stdlib/test/StringWrapper/CommonStringWrapperTest.php:153
/__w/laminas-stdlib/laminas-stdlib/vendor/phpunit/phpunit/phpunit:61

--

There was 1 failure:

1) LaminasTest\Stdlib\GlobTest::testPatterns with data set #0 ('{{,*.}alph,{,*.}bet}a', array('alpha', 'eta.alpha', 'zeta.alpha', 'beta', 'eta.beta', 'zeta.beta'))
Failed asserting that actual size 0 matches expected size 6.

/__w/laminas-stdlib/laminas-stdlib/test/GlobTest.php:69
/__w/laminas-stdlib/laminas-stdlib/vendor/phpunit/phpunit/phpunit:61
```

The four errors about `iconv()` are because of a well-known issue with `ext-iconv` on Alpine Linux and not the fault of this package. I have added a check that skips `IconvTest` on Alpine Linux. See the following links for further information on this issue:

- https://github.com/nunomaduro/phpinsights/issues/43
- https://github.com/docker-library/php/issues/240#issuecomment-353678474

The one failure is exactly the issue introduced in #43 with a wrong negation. That is fixed with the last commit of this PR.