### PR TITLE
Fixes crash in `StringUtils::registerWrapper()`

### DIFF
--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -21,7 +21,7 @@ abstract class StringUtils
     /**
      * Ordered list of registered string wrapper instances
      *
-     * @var list<class-string<StringWrapperInterface>>
+     * @var list<class-string<StringWrapperInterface>>|null
      */
     protected static $wrapperRegistry = null;
 
@@ -49,7 +49,7 @@ abstract class StringUtils
     /**
      * Get registered wrapper classes
      *
-     * @return string[]
+     * @return list<class-string<StringWrapperInterface>>
      */
     public static function getRegisteredWrappers()
     {
@@ -77,7 +77,7 @@ abstract class StringUtils
     /**
      * Register a string wrapper class
      *
-     * @param string $wrapper
+     * @param class-string<StringWrapperInterface> $wrapper
      * @return void
      */
     public static function registerWrapper($wrapper)
@@ -92,7 +92,7 @@ abstract class StringUtils
     /**
      * Unregister a string wrapper class
      *
-     * @param string $wrapper
+     * @param class-string<StringWrapperInterface> $wrapper
      * @return void
      */
     public static function unregisterWrapper($wrapper)

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -83,7 +83,8 @@ abstract class StringUtils
     public static function registerWrapper($wrapper)
     {
         $wrapper = (string) $wrapper;
-        if (!in_array($wrapper, static::$wrapperRegistry, true)) {
+        // using getRegisteredWrappers() here to ensure that the list is initialized
+        if (!in_array($wrapper, static::getRegisteredWrappers(), true)) {
             static::$wrapperRegistry[] = $wrapper;
         }
     }
@@ -96,7 +97,8 @@ abstract class StringUtils
      */
     public static function unregisterWrapper($wrapper)
     {
-        $index = array_search((string) $wrapper, static::$wrapperRegistry, true);
+        // using getRegisteredWrappers() here to ensure that the list is initialized
+        $index = array_search((string) $wrapper, static::getRegisteredWrappers(), true);
         if ($index !== false) {
             unset(static::$wrapperRegistry[$index]);
         }

--- a/src/StringUtils.php
+++ b/src/StringUtils.php
@@ -21,7 +21,7 @@ abstract class StringUtils
     /**
      * Ordered list of registered string wrapper instances
      *
-     * @var StringWrapperInterface[]
+     * @var list<class-string<StringWrapperInterface>>
      */
     protected static $wrapperRegistry = null;
 

--- a/test/StringUtilsTest.php
+++ b/test/StringUtilsTest.php
@@ -171,6 +171,7 @@ class StringUtilsTest extends TestCase
         // then verify that native is contained in the wrapper list
         $this->assertContains(Native::class, StringUtils::getRegisteredWrappers());
 
+        StringUtils::resetRegisteredWrappers();
         StringUtils::unregisterWrapper(Native::class);
 
         $this->assertNotContains(Native::class, StringUtils::getRegisteredWrappers());

--- a/test/StringUtilsTest.php
+++ b/test/StringUtilsTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Stdlib;
 
 use Laminas\Stdlib\ErrorHandler;
 use Laminas\Stdlib\StringUtils;
+use Laminas\Stdlib\StringWrapper\Native;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class StringUtilsTest extends TestCase
@@ -154,5 +155,24 @@ class StringUtilsTest extends TestCase
         ErrorHandler::stop();
 
         $this->assertSame($expected, StringUtils::hasPcreUnicodeSupport());
+    }
+
+    public function testRegisterSpecificWrapper()
+    {
+        StringUtils::resetRegisteredWrappers();
+        StringUtils::registerWrapper('MyAwesomeWrapper');
+
+        $this->assertContains('MyAwesomeWrapper', StringUtils::getRegisteredWrappers());
+    }
+
+    public function testUnregisterSpecificWrapper()
+    {
+        // initialize the list with defaults
+        // then verify that native is contained in the wrapper list
+        $this->assertContains(Native::class, StringUtils::getRegisteredWrappers());
+
+        StringUtils::unregisterWrapper(Native::class);
+
+        $this->assertNotContains(Native::class, StringUtils::getRegisteredWrappers());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fixes #51 