### PR TITLE
Fix for #50 - added `ReturnTypeWillChange` to `ArrayStack#getIterator()`, to comply with PHP 8.1 requirements

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit 
+<phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
-    colors="true">
+    colors="true"
+    convertDeprecationsToExceptions="true"
+>
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src</directory>

--- a/src/ArrayStack.php
+++ b/src/ArrayStack.php
@@ -6,6 +6,7 @@ namespace Laminas\Stdlib;
 
 use ArrayIterator;
 use ArrayObject as PhpArrayObject;
+use ReturnTypeWillChange;
 
 use function array_reverse;
 
@@ -22,6 +23,7 @@ class ArrayStack extends PhpArrayObject
      *
      * @return ArrayIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $array = $this->getArrayCopy();

--- a/test/ArrayStackTest.php
+++ b/test/ArrayStackTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stdlib;
+
+use Laminas\Stdlib\ArrayStack;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+
+/** @covers \Laminas\Stdlib\ArrayStack */
+final class ArrayStackTest extends TestCase
+{
+    public function testIteration(): void
+    {
+        self::assertSame(
+            ['c', 'b', 'a'],
+            iterator_to_array(new ArrayStack(['a', 'b', 'c']))
+        );
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Also marked any future detected deprecations as failures

Fixes #50