### PR TITLE
Fix incorrect return type annotation when `EXTR_DATA` is used when extracting data from a `PriorityQueue`

### DIFF
--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -277,7 +277,7 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      *
      * @param  int $flag
      * @return array<array-key, mixed>
-     * @psalm-return ($flag is self::EXTR_DATA
+     * @psalm-return ($flag is self::EXTR_BOTH
      *                      ? list<array{data: T, priority: TPriority}>
      *                      : $flag is self::EXTR_PRIORITY
      *                          ? list<TPriority>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

`EXTR_DATA` = `list<T>` but the return type had the expected result for `EXTR_BOTH` listed as the first possible value.

Sorry!