### PR TITLE
Relax param type of `ArrayUtils::iteratorToArray()` to accept `iterable` input

### DIFF
--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -222,8 +222,8 @@ abstract class ArrayUtils
      *
      * @template TKey
      * @template TValue
-     * @param  array<TKey, TValue>|Traversable<TKey, TValue> $iterator  The array or Traversable object to convert
-     * @param  bool                                          $recursive Recursively check all nested structures
+     * @param  iterable<TKey, TValue> $iterator  The array or Traversable object to convert
+     * @param  bool                   $recursive Recursively check all nested structures
      * @throws Exception\InvalidArgumentException If $iterator is not an array or a Traversable object.
      * @return array<TKey, TValue>
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Relax `$iterator` parameter type of `ArrayUtils::iteratorToArray` to allow all `iterable` types and not just `Traversable`.
