### PR TITLE
Dropping `@psalm-self-out` to avoid incorrect type inference in inheritance

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,14 +29,12 @@
     <DocblockTypeContradiction occurrences="1">
       <code>! is_array($data) &amp;&amp; ! is_object($data)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
-      <code>$key</code>
-      <code>$value</code>
-    </InvalidArgument>
-    <InvalidPropertyAssignmentValue occurrences="2">
-      <code>$data</code>
+    <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;storage</code>
     </InvalidPropertyAssignmentValue>
+    <MixedArgument occurrences="1">
+      <code>$v</code>
+    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$v</code>
     </MixedAssignment>
@@ -100,14 +98,12 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>TValue|int|array{data: TValue|false, priority: int}|false</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;values</code>
-    </InvalidPropertyAssignmentValue>
     <LessSpecificReturnStatement occurrences="3">
       <code>$array</code>
       <code>$value</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
+      <code>$item['data']</code>
       <code>$item['priority']</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="2">
@@ -172,32 +168,13 @@
       <code>setMetadata</code>
     </MissingReturnType>
   </file>
-  <file src="src/Parameters.php">
-    <InvalidArgument occurrences="3">
-      <code>$name</code>
-      <code>$name</code>
-      <code>$value</code>
-    </InvalidArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;toArray()</code>
-    </MixedArgumentTypeCoercion>
-    <MoreSpecificImplementedParamType occurrences="1">
-      <code>$name</code>
-    </MoreSpecificImplementedParamType>
-  </file>
   <file src="src/PriorityList.php">
     <FalsableReturnStatement occurrences="1">
       <code>$node ? $node['data'] : false</code>
     </FalsableReturnStatement>
-    <InvalidArrayOffset occurrences="1">
-      <code>$this-&gt;items[$name]</code>
-    </InvalidArrayOffset>
     <InvalidFalsableReturnType occurrences="1">
       <code>current</code>
     </InvalidFalsableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;items</code>
-    </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement occurrences="1">
       <code>$node ? $node['data'] : false</code>
     </InvalidReturnStatement>
@@ -466,11 +443,6 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="test/PriorityListTest.php">
-    <MixedAssignment occurrences="3">
-      <code>$orders1[$this-&gt;list-&gt;key()]</code>
-      <code>$orders2[$key]</code>
-      <code>$value</code>
-    </MixedAssignment>
     <NullArgument occurrences="5">
       <code>null</code>
       <code>null</code>

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -112,7 +112,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @template TInputValue
      * @param TInputKey $key
      * @param TInputValue $value
-     * @psalm-self-out ArrayObject<TKey|TInputKey, TValue|TInputValue>
+     * @psalm-self-out static&ArrayObject<TKey|TInputKey, TValue|TInputValue>
      * @return void
      */
     public function __set(mixed $key, mixed $value)
@@ -175,7 +175,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      *
      * @template TInputValue
      * @param TInputValue $value
-     * @psalm-self-out ArrayObject<TKey|int, TValue|TInputValue>
+     * @psalm-self-out static&ArrayObject<TKey|int, TValue|TInputValue>
      * @return void
      */
     public function append(mixed $value)
@@ -212,7 +212,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * // phpcs:disable Generic.Files.LineLength.TooLong
      * @param array<TInputKey, TInputValue>|ArrayObject<TInputKey, TInputValue>|ArrayIterator<TInputKey, TInputValue>|object $data
      * // phpcs:enable Generic.Files.LineLength.TooLong
-     * @psalm-self-out ArrayObject<TInputKey, TInputValue>
+     * @psalm-self-out static&ArrayObject<TInputKey, TInputValue>
      * @return array<TKey, TValue>
      */
     public function exchangeArray($data)

--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -108,11 +108,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Sets the value at the specified key to value
      *
-     * @template TInputKey of array-key
-     * @template TInputValue
-     * @param TInputKey $key
-     * @param TInputValue $value
-     * @psalm-self-out static&ArrayObject<TKey|TInputKey, TValue|TInputValue>
+     * @param TKey $key
+     * @param TValue $value
      * @return void
      */
     public function __set(mixed $key, mixed $value)
@@ -173,9 +170,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Appends the value
      *
-     * @template TInputValue
-     * @param TInputValue $value
-     * @psalm-self-out static&ArrayObject<TKey|int, TValue|TInputValue>
+     * @param TValue $value
      * @return void
      */
     public function append(mixed $value)
@@ -207,12 +202,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
     /**
      * Exchange the array for another one.
      *
-     * @template       TInputKey of array-key
-     * @template       TInputValue
-     * // phpcs:disable Generic.Files.LineLength.TooLong
-     * @param array<TInputKey, TInputValue>|ArrayObject<TInputKey, TInputValue>|ArrayIterator<TInputKey, TInputValue>|object $data
-     * // phpcs:enable Generic.Files.LineLength.TooLong
-     * @psalm-self-out static&ArrayObject<TInputKey, TInputValue>
+     * @param array<TKey, TValue>|ArrayObject<TKey, TValue>|ArrayIterator<TKey, TValue>|object $data
      * @return array<TKey, TValue>
      */
     public function exchangeArray($data)

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -118,7 +118,7 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * @template       TInputValue
      * @param TInputValue $value
      * @param int         $priority
-     * @psalm-self-out FastPriorityQueue<TValue|TInputValue>
+     * @psalm-self-out static&FastPriorityQueue<TValue|TInputValue>
      * @return void
      */
     public function insert(mixed $value, $priority)

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -115,10 +115,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
     /**
      * Insert an element in the queue with a specified priority
      *
-     * @template       TInputValue
-     * @param TInputValue $value
-     * @param int         $priority
-     * @psalm-self-out static&FastPriorityQueue<TValue|TInputValue>
+     * @param TValue $value
+     * @param int    $priority
      * @return void
      */
     public function insert(mixed $value, $priority)

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -11,7 +11,7 @@ use function http_build_query;
 use function parse_str;
 
 /**
- * @template TKey
+ * @template TKey of array-key
  * @template TValue
  * @template-extends PhpArrayObject<TKey, TValue>
  * @template-implements ParametersInterface<TKey, TValue>
@@ -37,10 +37,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
     /**
      * Populate from native PHP array
      *
-     * @template TInputKey of array-key
-     * @template TInputValue
-     * @param array<TInputKey, TInputValue> $values
-     * @psalm-self-out static&Parameters<TInputKey, TInputValue>
+     * @param array<TKey, TValue> $values
      * @return void
      */
     public function fromArray(array $values)
@@ -52,7 +49,6 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * Populate from query string
      *
      * @param  string $string
-     * @psalm-self-out static&Parameters<array-key, mixed>
      * @return void
      */
     public function fromString($string)
@@ -115,11 +111,8 @@ class Parameters extends PhpArrayObject implements ParametersInterface
     }
 
     /**
-     * @template       TInputKey of array-key
-     * @template       TInputValue
-     * @param TInputKey   $name
-     * @param TInputValue $value
-     * @psalm-self-out static&Parameters<TKey|TInputKey, TValue|TInputValue>
+     * @param TKey   $name
+     * @param TValue $value
      * @return $this
      */
     public function set($name, $value)

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -40,7 +40,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * @template TInputKey of array-key
      * @template TInputValue
      * @param array<TInputKey, TInputValue> $values
-     * @psalm-self-out Parameters<TInputKey, TInputValue>
+     * @psalm-self-out static&Parameters<TInputKey, TInputValue>
      * @return void
      */
     public function fromArray(array $values)
@@ -52,7 +52,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * Populate from query string
      *
      * @param  string $string
-     * @psalm-self-out Parameters<array-key, mixed>
+     * @psalm-self-out static&Parameters<array-key, mixed>
      * @return void
      */
     public function fromString($string)
@@ -119,7 +119,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      * @template       TInputValue
      * @param TInputKey   $name
      * @param TInputValue $value
-     * @psalm-self-out Parameters<TKey|TInputKey, TValue|TInputValue>
+     * @psalm-self-out static&Parameters<TKey|TInputKey, TValue|TInputValue>
      * @return $this
      */
     public function set($name, $value)

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -33,7 +33,7 @@ interface ParametersInterface extends ArrayAccess, Countable, Serializable, Trav
      *
      * Allow deserialization from standard array
      *
-     * @param array $values
+     * @param array<TKey, TValue> $values
      * @return mixed
      */
     public function fromArray(array $values);

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -74,7 +74,7 @@ class PriorityList implements Iterator, Countable
      * @param TInputKey   $name
      * @param TInputValue $value
      * @param int         $priority
-     * @psalm-self-out PriorityList<TInputKey|TKey, TInputValue|TValue>
+     * @psalm-self-out static&PriorityList<TInputKey|TKey, TInputValue|TValue>
      * @return void
      */
     public function insert($name, mixed $value, $priority = 0)

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -69,12 +69,9 @@ class PriorityList implements Iterator, Countable
     /**
      * Insert a new item.
      *
-     * @template       TInputKey of string
-     * @template       TInputValue
-     * @param TInputKey   $name
-     * @param TInputValue $value
-     * @param int         $priority
-     * @psalm-self-out static&PriorityList<TInputKey|TKey, TInputValue|TValue>
+     * @param TKey   $name
+     * @param TValue $value
+     * @param int    $priority
      * @return void
      */
     public function insert($name, mixed $value, $priority = 0)

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -48,6 +48,7 @@ class ArrayObjectTest extends TestCase
 
     public function testStdPropList(): void
     {
+        /** @var ArrayObject<string, string> $ar */
         $ar      = new ArrayObject();
         $ar->foo = 'bar';
         $ar->bar = 'baz';
@@ -96,6 +97,7 @@ class ArrayObjectTest extends TestCase
 
     public function testAppend(): void
     {
+        /** @var ArrayObject<int, string> $ar */
         $ar = new ArrayObject(['one', 'two']);
         self::assertEquals(2, $ar->count());
 
@@ -131,6 +133,7 @@ class ArrayObjectTest extends TestCase
 
     public function testExchangeArray(): void
     {
+        /** @var ArrayObject<string, string> $ar */
         $ar  = new ArrayObject(['foo' => 'bar']);
         $old = $ar->exchangeArray(['bar' => 'baz']);
 


### PR DESCRIPTION
Before this change, in following example, `@psalm-self-out` would delete inheritance type information at runtime.
For example:

```php
class Foo implements ParentType {
    // ...
}

$foo = new Foo();

$foo->methodWithSelfOut();

/** @psalm-trace $foo */ // produces `ParentType`
```

This change corrects that, preserving `static` in the type information.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
