### PR TITLE
General type inference improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.5",
         "phpbench/phpbench": "^1.2.14",
-        "phpunit/phpunit": "^10.2.6",
+        "phpunit/phpunit": "^10.3.3",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.13.1"
+        "vimeo/psalm": "^5.15.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75c1832fce2931fbc831d671a2fb529b",
+    "content-hash": "a832d1ae7e64a7580e8eaddf1524af17",
     "packages": [],
     "packages-dev": [
         {
@@ -319,16 +319,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -378,9 +378,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -396,7 +396,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1059,16 +1059,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -1109,9 +1109,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1627,16 +1627,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.3",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "be1fe461fdc917de2a29a452ccf2657d325b443d"
+                "reference": "cd59bb34756a16ca8253ce9b2909039c227fff71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/be1fe461fdc917de2a29a452ccf2657d325b443d",
-                "reference": "be1fe461fdc917de2a29a452ccf2657d325b443d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/cd59bb34756a16ca8253ce9b2909039c227fff71",
+                "reference": "cd59bb34756a16ca8253ce9b2909039c227fff71",
                 "shasum": ""
             },
             "require": {
@@ -1693,7 +1693,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.4"
             },
             "funding": [
                 {
@@ -1701,20 +1701,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-26T13:45:28+00:00"
+            "time": "2023-08-31T14:04:38+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "5647d65443818959172645e7ed999217360654b6"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
-                "reference": "5647d65443818959172645e7ed999217360654b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
@@ -1754,7 +1754,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -1762,7 +1762,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T09:13:23+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1829,16 +1829,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
@@ -1876,7 +1876,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1884,7 +1885,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:46+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1947,16 +1948,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.6",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1c17815c129f133f3019cc18e8d0c8622e6d9bcd"
+                "reference": "241ed4dd0db1c096984e62d414c4e1ac8d5dbff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1c17815c129f133f3019cc18e8d0c8622e6d9bcd",
-                "reference": "1c17815c129f133f3019cc18e8d0c8622e6d9bcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/241ed4dd0db1c096984e62d414c4e1ac8d5dbff4",
+                "reference": "241ed4dd0db1c096984e62d414c4e1ac8d5dbff4",
                 "shasum": ""
             },
             "require": {
@@ -1981,7 +1982,7 @@
                 "sebastian/diff": "^5.0",
                 "sebastian/environment": "^6.0",
                 "sebastian/exporter": "^5.0",
-                "sebastian/global-state": "^6.0",
+                "sebastian/global-state": "^6.0.1",
                 "sebastian/object-enumerator": "^5.0",
                 "sebastian/recursion-context": "^5.0",
                 "sebastian/type": "^4.0",
@@ -1996,7 +1997,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.2-dev"
+                    "dev-main": "10.3-dev"
                 }
             },
             "autoload": {
@@ -2028,7 +2029,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.3.3"
             },
             "funding": [
                 {
@@ -2044,7 +2045,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-17T12:08:28+00:00"
+            "time": "2023-09-05T04:34:51+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2427,16 +2428,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
@@ -2447,7 +2448,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
@@ -2491,7 +2492,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2499,20 +2501,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:16+00:00"
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
+                "reference": "c70b73893e10757af9c6a48929fa6a333b56a97a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c70b73893e10757af9c6a48929fa6a333b56a97a",
+                "reference": "c70b73893e10757af9c6a48929fa6a333b56a97a",
                 "shasum": ""
             },
             "require": {
@@ -2548,7 +2550,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.1"
             },
             "funding": [
                 {
@@ -2556,7 +2559,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:47+00:00"
+            "time": "2023-08-31T09:55:53+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2830,16 +2833,16 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
                 "shasum": ""
             },
             "require": {
@@ -2875,7 +2878,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
             },
             "funding": [
                 {
@@ -2883,7 +2887,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:02+00:00"
+            "time": "2023-08-31T09:25:50+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -3416,16 +3420,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.3.0",
+            "version": "v6.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7"
+                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7",
-                "reference": "8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/eca495f2ee845130855ddf1cf18460c38966c8b6",
+                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6",
                 "shasum": ""
             },
             "require": {
@@ -3486,7 +3490,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.3.0"
+                "source": "https://github.com/symfony/console/tree/v6.3.4"
             },
             "funding": [
                 {
@@ -3502,7 +3506,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-29T12:49:39+00:00"
+            "time": "2023-08-16T10:10:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3636,16 +3640,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.3.0",
+            "version": "v6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "d9b01ba073c44cef617c7907ce2419f8d00d75e2"
+                "reference": "9915db259f67d21eefee768c1abcf1cc61b1fc9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/d9b01ba073c44cef617c7907ce2419f8d00d75e2",
-                "reference": "d9b01ba073c44cef617c7907ce2419f8d00d75e2",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9915db259f67d21eefee768c1abcf1cc61b1fc9e",
+                "reference": "9915db259f67d21eefee768c1abcf1cc61b1fc9e",
                 "shasum": ""
             },
             "require": {
@@ -3680,7 +3684,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.3.0"
+                "source": "https://github.com/symfony/finder/tree/v6.3.3"
             },
             "funding": [
                 {
@@ -3696,7 +3700,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-02T01:25:41+00:00"
+            "time": "2023-07-31T08:31:44+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3767,16 +3771,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -3791,7 +3795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3829,7 +3833,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3845,20 +3849,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -3870,7 +3874,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3910,7 +3914,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3926,20 +3930,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -3951,7 +3955,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3994,7 +3998,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4010,20 +4014,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -4038,7 +4042,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4077,7 +4081,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4093,20 +4097,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.3.0",
+            "version": "v6.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8741e3ed7fe2e91ec099e02446fb86667a0f1628"
+                "reference": "0b5c29118f2e980d455d2e34a5659f4579847c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8741e3ed7fe2e91ec099e02446fb86667a0f1628",
-                "reference": "8741e3ed7fe2e91ec099e02446fb86667a0f1628",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0b5c29118f2e980d455d2e34a5659f4579847c54",
+                "reference": "0b5c29118f2e980d455d2e34a5659f4579847c54",
                 "shasum": ""
             },
             "require": {
@@ -4138,7 +4142,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.3.0"
+                "source": "https://github.com/symfony/process/tree/v6.3.4"
             },
             "funding": [
                 {
@@ -4154,7 +4158,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-19T08:06:44+00:00"
+            "time": "2023-08-07T10:39:22+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4240,16 +4244,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.3.0",
+            "version": "v6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f"
+                "reference": "53d1a83225002635bca3482fcbf963001313fb68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
-                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/53d1a83225002635bca3482fcbf963001313fb68",
+                "reference": "53d1a83225002635bca3482fcbf963001313fb68",
                 "shasum": ""
             },
             "require": {
@@ -4306,7 +4310,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.0"
+                "source": "https://github.com/symfony/string/tree/v6.3.2"
             },
             "funding": [
                 {
@@ -4322,7 +4326,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-21T21:06:29+00:00"
+            "time": "2023-07-05T08:41:27+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4376,16 +4380,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.13.1",
+            "version": "5.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "086b94371304750d1c673315321a55d15fc59015"
+                "reference": "5c774aca4746caf3d239d9c8cadb9f882ca29352"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/086b94371304750d1c673315321a55d15fc59015",
-                "reference": "086b94371304750d1c673315321a55d15fc59015",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/5c774aca4746caf3d239d9c8cadb9f882ca29352",
+                "reference": "5c774aca4746caf3d239d9c8cadb9f882ca29352",
                 "shasum": ""
             },
             "require": {
@@ -4406,12 +4410,15 @@
                 "felixfbecker/language-server-protocol": "^1.5.2",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.14",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+                "nikic/php-parser": "^4.16",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "sebastian/diff": "^4.0 || ^5.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
+            },
+            "conflict": {
+                "nikic/php-parser": "4.17.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -4476,9 +4483,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.13.1"
+                "source": "https://github.com/vimeo/psalm/tree/5.15.0"
             },
-            "time": "2023-06-27T16:39:49+00:00"
+            "time": "2023-08-20T23:07:30+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4655,5 +4662,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,25 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/AbstractOptions.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($options) && ! $options instanceof Traversable]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$letter</code>
+      <code>$value</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$array[$normalizedKey]</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$letter</code>
-      <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RawObjectIteration>
-      <code>$this</code>
-    </RawObjectIteration>
+    <MixedInferredReturnType>
+      <code>TValue</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->{$getter}()]]></code>
+    </MixedReturnStatement>
   </file>
   <file src="src/ArrayObject.php">
     <ArgumentTypeCoercion>
@@ -308,14 +304,8 @@
     </InvalidArgument>
     <MissingClosureParamType>
       <code>$a</code>
-      <code>$a</code>
-      <code>$b</code>
       <code>$b</code>
     </MissingClosureParamType>
-    <MixedArgument>
-      <code>$a</code>
-      <code>$b</code>
-    </MixedArgument>
     <MixedAssignment>
       <code>$unserialized</code>
     </MixedAssignment>
@@ -374,24 +364,8 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/FastPriorityQueueTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
-    <MissingClosureParamType>
-      <code>$e</code>
-      <code>$e</code>
-    </MissingClosureParamType>
-    <MixedArgument>
-      <code>$unserialized</code>
-      <code>$unserialized</code>
-    </MixedArgument>
     <MixedAssignment>
       <code>$datum</code>
-      <code>$expected[]</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$item</code>
       <code>$item</code>
       <code>$test[]</code>
       <code>$test[]</code>
@@ -399,12 +373,6 @@
       <code>$test[]</code>
       <code>$test[]</code>
       <code>$test[]</code>
-      <code>$test[]</code>
-      <code>$test[]</code>
-      <code>$test[]</code>
-      <code>$unserialized</code>
-      <code>$value</code>
-      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -413,33 +381,13 @@
   </file>
   <file src="test/GlobTest.php">
     <MixedArgument>
-      <code>$expectedFileName</code>
       <code>$result[$i]</code>
     </MixedArgument>
-    <MixedAssignment>
-      <code>$expectedFileName</code>
-    </MixedAssignment>
     <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="test/OptionsTest.php">
-    <InternalMethod>
-      <code>addToAssertionCount</code>
-    </InternalMethod>
-    <InvalidArgument>
-      <code><![CDATA['asd']]></code>
-      <code><![CDATA[new TestOptions(['test_field' => 1])]]></code>
-    </InvalidArgument>
-  </file>
   <file src="test/ParametersTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA['ArrayAccess']]></code>
-      <code><![CDATA['ArrayObject']]></code>
-      <code><![CDATA['Countable']]></code>
-      <code><![CDATA['Serializable']]></code>
-      <code><![CDATA['Traversable']]></code>
-    </ArgumentTypeCoercion>
     <UndefinedPropertyFetch>
       <code><![CDATA[$parameters->bar]]></code>
       <code><![CDATA[$parameters->baz]]></code>
@@ -448,67 +396,5 @@
       <code><![CDATA[$parameters->foo]]></code>
       <code><![CDATA[$parameters->foof]]></code>
     </UndefinedPropertyFetch>
-  </file>
-  <file src="test/PriorityListTest.php">
-    <NullArgument>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </NullArgument>
-    <TypeDoesNotContainType>
-      <code>assertEmpty</code>
-    </TypeDoesNotContainType>
-  </file>
-  <file src="test/PriorityQueueTest.php">
-    <MixedArgument>
-      <code>$unserialized</code>
-      <code>$unserialized</code>
-      <code>$unserialized</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$item</code>
-      <code>$test[]</code>
-      <code>$unserialized</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/SplQueueTest.php">
-    <MixedArgument>
-      <code>$unserialized</code>
-      <code>$unserialized</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$unserialized</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/SplStackTest.php">
-    <MixedArgument>
-      <code>$unserialized</code>
-      <code>$unserialized</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$unserialized</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/StringUtilsTest.php">
-    <MixedArgument>
-      <code>$str</code>
-    </MixedArgument>
-  </file>
-  <file src="test/StringWrapper/IconvTest.php">
-    <TooManyArguments>
-      <code><![CDATA[new Iconv('utf-8')]]></code>
-    </TooManyArguments>
-  </file>
-  <file src="test/StringWrapper/IntlTest.php">
-    <TooManyArguments>
-      <code><![CDATA[new Intl('utf-8')]]></code>
-    </TooManyArguments>
-  </file>
-  <file src="test/StringWrapper/MbStringTest.php">
-    <TooManyArguments>
-      <code><![CDATA[new MbString('utf-8')]]></code>
-    </TooManyArguments>
   </file>
 </files>

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -7,6 +7,7 @@ namespace Laminas\Stdlib;
 use Traversable;
 
 use function array_shift;
+use function get_object_vars;
 use function is_array;
 use function is_callable;
 use function method_exists;
@@ -16,6 +17,10 @@ use function str_replace;
 use function strtolower;
 use function ucwords;
 
+/**
+ * @template TValue
+ * @implements ParameterObjectInterface<string, TValue>
+ */
 abstract class AbstractOptions implements ParameterObjectInterface
 {
     // phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore,WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCapsProperty
@@ -33,7 +38,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Constructor
      *
-     * @param  array|Traversable|null $options
+     * @param  iterable<string, TValue>|AbstractOptions<TValue>|null $options
      */
     public function __construct($options = null)
     {
@@ -45,7 +50,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Set one or more configuration properties
      *
-     * @param  array|Traversable|AbstractOptions $options
+     * @param  iterable<string, TValue>|AbstractOptions<TValue> $options
      * @throws Exception\InvalidArgumentException
      * @return AbstractOptions Provides fluent interface
      */
@@ -77,19 +82,20 @@ abstract class AbstractOptions implements ParameterObjectInterface
     /**
      * Cast to array
      *
-     * @return array
+     * @return array<string, TValue>
      */
     public function toArray()
     {
         $array = [];
 
-        /** @param string[] $letters */
         $transform = static function (array $letters): string {
+            /** @var list<string> $letters */
             $letter = array_shift($letters);
             return '_' . strtolower($letter);
         };
 
-        foreach ($this as $key => $value) {
+        /** @psalm-var TValue $value */
+        foreach (get_object_vars($this) as $key => $value) {
             if ($key === '__strictMode__') {
                 continue;
             }
@@ -106,7 +112,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
      * @see ParameterObject::__set()
      *
      * @param string $key
-     * @param mixed $value
+     * @param TValue|null $value
      * @throws Exception\BadMethodCallException
      * @return void
      */
@@ -137,7 +143,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
      *
      * @param string $key
      * @throws Exception\BadMethodCallException
-     * @return mixed
+     * @return TValue
      */
     public function __get($key)
     {

--- a/src/ParameterObjectInterface.php
+++ b/src/ParameterObjectInterface.php
@@ -4,28 +4,33 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @template TKey of string
+ * @template TValue
+ */
 interface ParameterObjectInterface
 {
     /**
-     * @param string $key
+     * @param TKey $key
+     * @param TValue|null $value
      * @return void
      */
     public function __set($key, mixed $value);
 
     /**
-     * @param string $key
-     * @return mixed
+     * @param TKey $key
+     * @return TValue
      */
     public function __get($key);
 
     /**
-     * @param string $key
+     * @param TKey $key
      * @return bool
      */
     public function __isset($key);
 
     /**
-     * @param string $key
+     * @param TKey $key
      * @return void
      */
     public function __unset($key);

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -369,7 +369,7 @@ class ArrayObjectTest extends TestCase
 
     public function testUksort(): void
     {
-        $function = static function ($a, $b): int {
+        $function = static function (string $a, string $b): int {
             $a = preg_replace('@^(a|an|the) @', '', $a);
             $b = preg_replace('@^(a|an|the) @', '', $b);
             self::assertNotNull($a);

--- a/test/FastPriorityQueueTest.php
+++ b/test/FastPriorityQueueTest.php
@@ -21,14 +21,15 @@ use function var_export;
 #[Group('Laminas_Stdlib')]
 class FastPriorityQueueTest extends TestCase
 {
-    /** @var FastPriorityQueue */
-    protected $queue;
+    /** @var FastPriorityQueue<string> */
+    private FastPriorityQueue $queue;
 
     /** @var string[] */
-    protected $expected;
+    private array $expected;
 
     protected function setUp(): void
     {
+        /** @psalm-var FastPriorityQueue<string> $this->queue */
         $this->queue = new FastPriorityQueue();
         $this->insertDataQueue($this->queue);
         $this->expected = [
@@ -107,7 +108,8 @@ class FastPriorityQueueTest extends TestCase
     {
         $s            = serialize($this->queue);
         $unserialized = unserialize($s);
-        $count        = count($this->queue);
+        self::assertInstanceOf(FastPriorityQueue::class, $unserialized);
+        $count = count($this->queue);
         self::assertSame(
             $count,
             count($unserialized),
@@ -168,6 +170,7 @@ class FastPriorityQueueTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The extract flag specified is not valid');
+        /** @psalm-suppress InvalidArgument */
         $this->queue->setExtractFlags('foo');
     }
 
@@ -191,7 +194,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testHasPriority(): void
     {
-        foreach ($this->getDataPriorityQueue() as $value => $priority) {
+        foreach ($this->getDataPriorityQueue() as $priority) {
             self::assertTrue($this->queue->hasPriority($priority));
         }
         self::assertFalse($this->queue->hasPriority(10000));
@@ -211,7 +214,7 @@ class FastPriorityQueueTest extends TestCase
         self::assertEquals($expected, $test);
     }
 
-    public function testRemoveOnlyTheFirstOccurenceFromQueue(): void
+    public function testRemoveOnlyTheFirstOccurrenceFromQueue(): void
     {
         $data = $this->getDataPriorityQueue();
         $this->queue->insert('test2', $data['test2']);
@@ -246,7 +249,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testRemoveShouldFindItemEvenIfMultipleItemsAreInQueue(): void
     {
-        $prototype = static function ($e): void {
+        $prototype = static function (): void {
         };
 
         $queue = new FastPriorityQueue();
@@ -268,7 +271,7 @@ class FastPriorityQueueTest extends TestCase
 
     public function testIterativelyRemovingItemsShouldRemoveAllItems(): void
     {
-        $prototype = static function ($e): void {
+        $prototype = static function (): void {
         };
 
         $queue = new FastPriorityQueue();

--- a/test/GlobTest.php
+++ b/test/GlobTest.php
@@ -60,6 +60,7 @@ class GlobTest extends TestCase
         Glob::glob($path);
     }
 
+    /** @param list<non-empty-string> $expectedSequence */
     #[DataProvider('patternsProvider')]
     public function testPatterns(string $pattern, array $expectedSequence): void
     {
@@ -75,7 +76,7 @@ class GlobTest extends TestCase
     /**
      * @psalm-return array<array-key, array{
      *     0: string,
-     *     1: string[]
+     *     1: list<non-empty-string>
      * }>
      */
     public static function patternsProvider(): array

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -63,9 +63,9 @@ class OptionsTest extends TestCase
     {
         $options = new TestOptions(['test_field' => 1]);
 
-        self::assertEquals(true, isset($options->test_field));
+        self::assertTrue(isset($options->test_field));
         unset($options->testField);
-        self::assertEquals(false, isset($options->test_field));
+        self::assertFalse(isset($options->test_field));
     }
 
     public function testUnsetThrowsInvalidArgumentException(): void
@@ -99,6 +99,7 @@ class OptionsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $options = new TestOptions();
+        /** @psalm-suppress InvalidArgument */
         $options->setFromArray('asd');
     }
 
@@ -179,9 +180,7 @@ class OptionsTest extends TestCase
     {
         $options = new TestOptionsWithoutGetter();
 
-        isset($options->foo);
-
-        $this->addToAssertionCount(1);
+        self::assertFalse(isset($options->foo));
     }
 
     #[Group('7287')]

--- a/test/ParametersTest.php
+++ b/test/ParametersTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace LaminasTest\Stdlib;
 
+use ArrayAccess;
+use ArrayObject;
+use Countable;
 use Laminas\Stdlib\Parameters;
 use Laminas\Stdlib\ParametersInterface;
 use PHPUnit\Framework\TestCase;
+use Serializable;
+use Traversable;
 
 class ParametersTest extends TestCase
 {
@@ -14,11 +19,11 @@ class ParametersTest extends TestCase
     {
         $parameters = new Parameters();
         self::assertInstanceOf(ParametersInterface::class, $parameters);
-        self::assertInstanceOf('ArrayObject', $parameters);
-        self::assertInstanceOf('ArrayAccess', $parameters);
-        self::assertInstanceOf('Countable', $parameters);
-        self::assertInstanceOf('Serializable', $parameters);
-        self::assertInstanceOf('Traversable', $parameters);
+        self::assertInstanceOf(ArrayObject::class, $parameters);
+        self::assertInstanceOf(ArrayAccess::class, $parameters);
+        self::assertInstanceOf(Countable::class, $parameters);
+        self::assertInstanceOf(Serializable::class, $parameters);
+        self::assertInstanceOf(Traversable::class, $parameters);
     }
 
     public function testParametersPersistNameAndValues(): void
@@ -45,7 +50,7 @@ class ParametersTest extends TestCase
         self::assertEquals('barf', $parameters->foof);
     }
 
-    public function testParametersOffsetgetReturnsNullIfNonexistentKeyIsProvided(): void
+    public function testParametersOffsetGetReturnsNullIfNonexistentKeyIsProvided(): void
     {
         $parameters = new Parameters();
         self::assertNull($parameters->foo);

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -10,12 +10,11 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_keys;
-use function count;
 use function iterator_to_array;
 
 class PriorityListTest extends TestCase
 {
-    /** @var PriorityList */
+    /** @var PriorityList<string, mixed> */
     protected $list;
 
     protected function setUp(): void
@@ -27,7 +26,7 @@ class PriorityListTest extends TestCase
     {
         $this->list->insert('foo', new stdClass(), 0);
 
-        self::assertEquals(1, count($this->list));
+        self::assertCount(1, $this->list);
 
         $values = $this->list->toArray();
         self::assertArrayHasKey('foo', $values);
@@ -38,17 +37,17 @@ class PriorityListTest extends TestCase
         $this->list->insert('foo', new stdClass());
         $this->list->insert('bar', new stdClass());
 
-        self::assertEquals(2, count($this->list));
+        self::assertCount(2, $this->list);
 
         $this->list->insert('foo', new stdClass());
         $this->list->insert('foo', new stdClass());
         $this->list->insert('bar', new stdClass());
 
-        self::assertEquals(2, count($this->list));
+        self::assertCount(2, $this->list);
 
         $this->list->remove('foo');
 
-        self::assertEquals(1, count($this->list));
+        self::assertCount(1, $this->list);
     }
 
     public function testRemove(): void
@@ -56,18 +55,18 @@ class PriorityListTest extends TestCase
         $this->list->insert('foo', new stdClass(), 0);
         $this->list->insert('bar', new stdClass(), 0);
 
-        self::assertEquals(2, count($this->list));
+        self::assertCount(2, $this->list);
 
         $this->list->remove('foo');
 
-        self::assertEquals(1, count($this->list));
+        self::assertCount(1, $this->list);
     }
 
     public function testRemovingNonExistentRouteDoesNotYieldError(): void
     {
         $this->list->remove('foo');
 
-        self::assertEmpty($this->list);
+        self::assertEmpty($this->list->toArray());
     }
 
     public function testClear(): void
@@ -75,11 +74,11 @@ class PriorityListTest extends TestCase
         $this->list->insert('foo', new stdClass(), 0);
         $this->list->insert('bar', new stdClass(), 0);
 
-        self::assertEquals(2, count($this->list));
+        self::assertCount(2, $this->list);
 
         $this->list->clear();
 
-        self::assertEquals(0, count($this->list));
+        self::assertCount(0, $this->list);
         self::assertSame(false, $this->list->current());
     }
 
@@ -156,7 +155,7 @@ class PriorityListTest extends TestCase
 
     public function testPriorityWithNegativesAndNull(): void
     {
-        $this->list->insert('foo', new stdClass(), null);
+        $this->list->insert('foo', new stdClass());
         $this->list->insert('bar', new stdClass(), 1);
         $this->list->insert('baz', new stdClass(), -1);
 
@@ -167,7 +166,7 @@ class PriorityListTest extends TestCase
 
     public function testCurrent(): void
     {
-        $this->list->insert('foo', 'foo_value', null);
+        $this->list->insert('foo', 'foo_value');
         $this->list->insert('bar', 'bar_value', 1);
         $this->list->insert('baz', 'baz_value', -1);
 
@@ -187,7 +186,7 @@ class PriorityListTest extends TestCase
 
     public function testToArray(): void
     {
-        $this->list->insert('foo', 'foo_value', null);
+        $this->list->insert('foo', 'foo_value');
         $this->list->insert('bar', 'bar_value', 1);
         $this->list->insert('baz', 'baz_value', -1);
 
@@ -210,12 +209,13 @@ class PriorityListTest extends TestCase
         );
     }
 
+    /** @psalm-suppress MixedAssignment */
     #[Group('6768')]
     #[Group('6773')]
     public function testBooleanValuesAreValid(): void
     {
-        $this->list->insert('null', null, null);
-        $this->list->insert('false', false, null);
+        $this->list->insert('null', null);
+        $this->list->insert('false', false);
         $this->list->insert('string', 'test', 1);
         $this->list->insert('true', true, -1);
 

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -19,11 +19,12 @@ use function var_export;
 #[Group('Laminas_Stdlib')]
 class PriorityQueueTest extends TestCase
 {
-    /** @var PriorityQueue */
-    protected $queue;
+    /** @var PriorityQueue<string, int> */
+    private PriorityQueue $queue;
 
     protected function setUp(): void
     {
+        /** @psalm-var PriorityQueue<string, int> $this->queue */
         $this->queue = new PriorityQueue();
         $this->queue->insert('foo', 3);
         $this->queue->insert('bar', 4);
@@ -35,7 +36,8 @@ class PriorityQueueTest extends TestCase
     {
         $s            = serialize($this->queue);
         $unserialized = unserialize($s);
-        $count        = count($this->queue);
+        self::assertInstanceOf(PriorityQueue::class, $unserialized);
+        $count = count($this->queue);
         self::assertSame(
             $count,
             count($unserialized),

--- a/test/SplQueueTest.php
+++ b/test/SplQueueTest.php
@@ -31,8 +31,8 @@ class SplQueueTest extends TestCase
     {
         $s            = serialize($this->queue);
         $unserialized = unserialize($s);
-        $count        = count($this->queue);
-        self::assertSame($count, count($unserialized));
+        self::assertInstanceOf(SplQueue::class, $unserialized);
+        self::assertSame(count($this->queue), count($unserialized));
 
         $expected = iterator_to_array($this->queue);
         $test     = iterator_to_array($unserialized);

--- a/test/SplStackTest.php
+++ b/test/SplStackTest.php
@@ -33,8 +33,8 @@ class SplStackTest extends TestCase
     {
         $s            = serialize($this->stack);
         $unserialized = unserialize($s);
-        $count        = count($this->stack);
-        self::assertSame($count, count($unserialized));
+        self::assertInstanceOf(SplStack::class, $unserialized);
+        self::assertSame(count($this->stack), count($unserialized));
 
         $expected = iterator_to_array($this->stack);
         $test     = iterator_to_array($unserialized);

--- a/test/StringUtilsTest.php
+++ b/test/StringUtilsTest.php
@@ -154,12 +154,10 @@ class StringUtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @param bool $valid
-     */
     #[DataProvider('getUtf8StringValidity')]
-    public function testIsValidUtf8(mixed $str, $valid): void
+    public function testIsValidUtf8(mixed $str, bool $valid): void
     {
+        /** @psalm-suppress MixedArgument */
         self::assertSame($valid, StringUtils::isValidUtf8($str));
     }
 

--- a/test/StringWrapper/CommonStringWrapperTestCase.php
+++ b/test/StringWrapper/CommonStringWrapperTestCase.php
@@ -17,12 +17,10 @@ use const STR_PAD_RIGHT;
 // phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
 abstract class CommonStringWrapperTestCase extends TestCase
 {
-    /**
-     * @param null|string $encoding
-     * @param null|string $convertEncoding
-     * @return false|StringWrapperInterface
-     */
-    abstract protected function getWrapper($encoding = null, $convertEncoding = null);
+    abstract protected function getWrapper(
+        string|null $encoding = null,
+        string|null $convertEncoding = null,
+    ): StringWrapperInterface|false;
 
     /**
      * @psalm-return array<array-key, array{

--- a/test/StringWrapper/IconvTest.php
+++ b/test/StringWrapper/IconvTest.php
@@ -6,7 +6,6 @@ namespace LaminasTest\Stdlib\StringWrapper;
 
 use Laminas\Stdlib\Exception;
 use Laminas\Stdlib\StringWrapper\Iconv;
-use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
 
 use function array_shift;
 use function extension_loaded;
@@ -21,7 +20,7 @@ class IconvTest extends CommonStringWrapperTestCase
     {
         if (! extension_loaded('iconv')) {
             try {
-                new Iconv('utf-8');
+                new Iconv();
                 $this->fail('Missing expected Laminas\Stdlib\Exception\ExtensionNotLoadedException');
             } catch (Exception\ExtensionNotLoadedException) {
                 $this->markTestSkipped('Missing ext/iconv');
@@ -45,13 +44,10 @@ class IconvTest extends CommonStringWrapperTestCase
         parent::setUp();
     }
 
-    /**
-     * @param null|string $encoding
-     * @param null|string $convertEncoding
-     * @return false|StringWrapperInterface
-     */
-    protected function getWrapper($encoding = null, $convertEncoding = null)
-    {
+    protected function getWrapper(
+        string|null $encoding = null,
+        string|null $convertEncoding = null,
+    ): Iconv|false {
         if ($encoding === null) {
             $supportedEncodings = Iconv::getSupportedEncodings();
             $encoding           = array_shift($supportedEncodings);

--- a/test/StringWrapper/IntlTest.php
+++ b/test/StringWrapper/IntlTest.php
@@ -16,7 +16,7 @@ class IntlTest extends CommonStringWrapperTestCase
     {
         if (! extension_loaded('intl')) {
             try {
-                new Intl('utf-8');
+                new Intl();
                 $this->fail('Missing expected Laminas\Stdlib\Exception\ExtensionNotLoadedException');
             } catch (Exception\ExtensionNotLoadedException) {
                 $this->markTestSkipped('Missing ext/intl');
@@ -26,13 +26,10 @@ class IntlTest extends CommonStringWrapperTestCase
         parent::setUp();
     }
 
-    /**
-     * @param null|string $encoding
-     * @param null|string $convertEncoding
-     * @return Intl|false
-     */
-    protected function getWrapper($encoding = null, $convertEncoding = null)
-    {
+    protected function getWrapper(
+        string|null $encoding = null,
+        string|null $convertEncoding = null,
+    ): Intl|false {
         if ($encoding === null) {
             $supportedEncodings = Intl::getSupportedEncodings();
             $encoding           = array_shift($supportedEncodings);

--- a/test/StringWrapper/MbStringTest.php
+++ b/test/StringWrapper/MbStringTest.php
@@ -16,7 +16,7 @@ class MbStringTest extends CommonStringWrapperTestCase
     {
         if (! extension_loaded('mbstring')) {
             try {
-                new MbString('utf-8');
+                new MbString();
                 $this->fail('Missing expected Laminas\Stdlib\Exception\ExtensionNotLoadedException');
             } catch (Exception\ExtensionNotLoadedException) {
                 $this->markTestSkipped('Missing ext/mbstring');
@@ -26,13 +26,10 @@ class MbStringTest extends CommonStringWrapperTestCase
         parent::setUp();
     }
 
-    /**
-     * @param null|string $encoding
-     * @param null|string $convertEncoding
-     * @return MbString|false
-     */
-    protected function getWrapper($encoding = null, $convertEncoding = null)
-    {
+    protected function getWrapper(
+        string|null $encoding = null,
+        string|null $convertEncoding = null,
+    ): MbString|false {
         if ($encoding === null) {
             $supportedEncodings = MbString::getSupportedEncodings();
             $encoding           = array_shift($supportedEncodings);

--- a/test/StringWrapper/NativeTest.php
+++ b/test/StringWrapper/NativeTest.php
@@ -10,13 +10,10 @@ use function array_shift;
 
 class NativeTest extends CommonStringWrapperTestCase
 {
-    /**
-     * @param null|string $encoding
-     * @param null|string $convertEncoding
-     * @return Native|false
-     */
-    protected function getWrapper($encoding = null, $convertEncoding = null)
-    {
+    protected function getWrapper(
+        string|null $encoding = null,
+        string|null $convertEncoding = null,
+    ): Native|false {
         if ($encoding === null) {
             $supportedEncodings = Native::getSupportedEncodings();
             $encoding           = array_shift($supportedEncodings);

--- a/test/TestAsset/TestOptions.php
+++ b/test/TestAsset/TestOptions.php
@@ -8,28 +8,25 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Dummy TestOptions used to test Stdlib\Options
+ *
+ * @extends AbstractOptions<mixed>
  */
 class TestOptions extends AbstractOptions
 {
-    /** @var mixed */
-    protected $testField;
+    protected mixed $testField;
 
-    /** @var mixed */
-    private $parentPrivate;
+    private mixed $parentPrivate;
 
-    /** @var mixed */
-    protected $parentProtected;
+    protected mixed $parentProtected;
 
-    /** @var mixed */
-    protected $parentPublic;
+    protected mixed $parentPublic;
 
     public function setTestField(mixed $value): void
     {
         $this->testField = $value;
     }
 
-    /** @return mixed */
-    public function getTestField()
+    public function getTestField(): mixed
     {
         return $this->testField;
     }
@@ -44,10 +41,8 @@ class TestOptions extends AbstractOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    private function getParentPrivate()
+    private function getParentPrivate(): mixed
     {
         return $this->parentPrivate;
     }
@@ -62,10 +57,8 @@ class TestOptions extends AbstractOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    protected function getParentProtected()
+    protected function getParentProtected(): mixed
     {
         return $this->parentProtected;
     }
@@ -80,10 +73,8 @@ class TestOptions extends AbstractOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    public function getParentPublic()
+    public function getParentPublic(): mixed
     {
         return $this->parentPublic;
     }

--- a/test/TestAsset/TestOptionsDerived.php
+++ b/test/TestAsset/TestOptionsDerived.php
@@ -9,14 +9,11 @@ namespace LaminasTest\Stdlib\TestAsset;
  */
 class TestOptionsDerived extends TestOptions
 {
-    /** @var mixed */
-    private $derivedPrivate;
+    private mixed $derivedPrivate;
 
-    /** @var mixed */
-    protected $derivedProtected;
+    protected mixed $derivedProtected;
 
-    /** @var mixed */
-    protected $derivedPublic;
+    protected mixed $derivedPublic;
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
@@ -28,10 +25,8 @@ class TestOptionsDerived extends TestOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    private function getDerivedPrivate()
+    private function getDerivedPrivate(): mixed
     {
         return $this->derivedPrivate;
     }
@@ -46,10 +41,8 @@ class TestOptionsDerived extends TestOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    protected function getDerivedProtected()
+    protected function getDerivedProtected(): mixed
     {
         return $this->derivedProtected;
     }
@@ -64,10 +57,8 @@ class TestOptionsDerived extends TestOptions
 
     /**
      * Needed to test accessibility of getters / setters within deriving classes
-     *
-     * @return mixed
      */
-    public function getDerivedPublic()
+    public function getDerivedPublic(): mixed
     {
         return $this->derivedPublic;
     }

--- a/test/TestAsset/TestOptionsNoStrict.php
+++ b/test/TestAsset/TestOptionsNoStrict.php
@@ -8,6 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Dummy TestOptions used to test Stdlib\Options
+ *
+ * @extends AbstractOptions<mixed>
  */
 class TestOptionsNoStrict extends AbstractOptions
 {
@@ -18,16 +20,14 @@ class TestOptionsNoStrict extends AbstractOptions
 
     // phpcs:enable
 
-    /** @var mixed */
-    protected $testField;
+    protected mixed $testField;
 
     public function setTestField(mixed $value): void
     {
         $this->testField = $value;
     }
 
-    /** @return mixed */
-    public function getTestField()
+    public function getTestField(): mixed
     {
         return $this->testField;
     }

--- a/test/TestAsset/TestOptionsWithoutGetter.php
+++ b/test/TestAsset/TestOptionsWithoutGetter.php
@@ -8,11 +8,12 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Dummy TestOptions used to test Stdlib\Options
+ *
+ * @extends AbstractOptions<mixed>
  */
 class TestOptionsWithoutGetter extends AbstractOptions
 {
-    /** @var mixed */
-    protected $foo;
+    protected mixed $foo;
 
     public function setFoo(mixed $value): void
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

- Adds template parameters to ParameterObjectInterface and AbstractOptions
- Fixes a range of psalm issues, mostly in tests
- Updates the baseline
- Bumps dev dependencies and refreshes the lock file

Closes #97

Primarily, this patch is just to get renovate green again because psalm has made everything go red with various improvements.

Stdlib is also good to go for PHP 8.3, so I'll send in another patch for this.