### PR TITLE
Add parameter and return types to Queue, Stack and List types

### DIFF
--- a/docs/book/v4/migration/v3-to-v4.md
+++ b/docs/book/v4/migration/v3-to-v4.md
@@ -2,17 +2,28 @@
 
 Version 4 of `laminas-stdlib` contains a number of backwards incompatible changes. This guide is intended to help you upgrade from the version 3 series to version 4.
 
-### Parameter and return type hints have been added throughout
+### Parameter, property and return type hints have been added throughout
 
 All classes have been updated to make use of parameter and return types. In general usage, this should not pose too many problems, providing you have been passing the previously documented types to the methods that have changed, however, it is advisable to audit your existing usage of the library for potential type errors. A static analysis tool like Psalm or PHPStan will help you with this.
+
+The addition of property, parameter and return types will cause fatal errors for extending classes that re-define those properties or override changed methods. If you have extended from any classes in laminas-stdlib, you should check that property types and method signatures are compatible and update them if they are not aligned.
 
 ### Breaking changes to return types in iterable classes
 
 A number of Queue, Stack and Heap implementations have different return types in order to align with the built-in PHP interfaces that they implement such as `Iterator` or `IteratorAggregate` etc.
 
-#### Laminas\Stdlib\SplPriorityQueue
+#### `insert()` signature change for iterable types
 
-This class implements PHP's built-in `\SplPriorityQueue`
+PHP's built-in `\SplPriorityQueue`, `\SplHeap`, `\SplMinHeap` and other similar classes return `true` from the `insert()` method. Classes that either extend from or have similar semantics to these built-in types previously had varying return types such as `void`, `self`. From version 4, the method signature for `insert()` where implemented has been changed to `bool` _(true)_.
 
-- The `insert()` method previously returned `void`. This has been changed to `bool` to align with `\SplPriorityQueue`
-- 
+- `Laminas\Stdlib\SplPriorityQueue::insert()` previously returned `void`. This has been changed to `bool` to align with `\SplPriorityQueue`
+- `Laminas\Stdlib\PriorityQueue::insert()` previously returned `self`. This has been changed to `bool` for consistency
+- `Laminas\Stdlib\PriorityList::insert()` previously returned `void`. This has been changed to `bool` for consistency
+- `Laminas\Stdlib\FastPriorityQueue::insert()` previously returned `void`. This has been changed to `bool` for consistency
+
+#### Other method signature changes
+
+##### `Laminas\Stdlib\PriorityList`
+
+- `next()` previously returned `false` or the node value at the next index and now returns `void` to align with the `Iterator` interface.
+- `setPriority()` previously returned `self` and now returns `void` for consistency.

--- a/docs/book/v4/migration/v3-to-v4.md
+++ b/docs/book/v4/migration/v3-to-v4.md
@@ -2,17 +2,17 @@
 
 Version 4 of `laminas-stdlib` contains a number of backwards incompatible changes. This guide is intended to help you upgrade from the version 3 series to version 4.
 
-### Parameter, property and return type hints have been added throughout
+### Parameter, Property and Return Type Hints Have Been Added Throughout
 
 All classes have been updated to make use of parameter and return types. In general usage, this should not pose too many problems, providing you have been passing the previously documented types to the methods that have changed, however, it is advisable to audit your existing usage of the library for potential type errors. A static analysis tool like Psalm or PHPStan will help you with this.
 
 The addition of property, parameter and return types will cause fatal errors for extending classes that re-define those properties or override changed methods. If you have extended from any classes in laminas-stdlib, you should check that property types and method signatures are compatible and update them if they are not aligned.
 
-### Breaking changes to return types in iterable classes
+### Breaking Changes to Return Types in Iterable Classes
 
 A number of Queue, Stack and Heap implementations have different return types in order to align with the built-in PHP interfaces that they implement such as `Iterator` or `IteratorAggregate` etc.
 
-#### `insert()` signature change for iterable types
+#### `insert()` Signature Change for Iterable Types
 
 PHP's built-in `\SplPriorityQueue`, `\SplHeap`, `\SplMinHeap` and other similar classes return `true` from the `insert()` method. Classes that either extend from or have similar semantics to these built-in types previously had varying return types such as `void`, `self`. From version 4, the method signature for `insert()` where implemented has been changed to `bool` _(true)_.
 
@@ -21,7 +21,7 @@ PHP's built-in `\SplPriorityQueue`, `\SplHeap`, `\SplMinHeap` and other similar 
 - `Laminas\Stdlib\PriorityList::insert()` previously returned `void`. This has been changed to `bool` for consistency
 - `Laminas\Stdlib\FastPriorityQueue::insert()` previously returned `void`. This has been changed to `bool` for consistency
 
-#### Other method signature changes
+#### Other Method Signature Changes
 
 ##### `Laminas\Stdlib\PriorityList`
 

--- a/docs/book/v4/migration/v3-to-v4.md
+++ b/docs/book/v4/migration/v3-to-v4.md
@@ -1,3 +1,18 @@
 # Migration from Version 3 to 4
 
 Version 4 of `laminas-stdlib` contains a number of backwards incompatible changes. This guide is intended to help you upgrade from the version 3 series to version 4.
+
+### Parameter and return type hints have been added throughout
+
+All classes have been updated to make use of parameter and return types. In general usage, this should not pose too many problems, providing you have been passing the previously documented types to the methods that have changed, however, it is advisable to audit your existing usage of the library for potential type errors. A static analysis tool like Psalm or PHPStan will help you with this.
+
+### Breaking changes to return types in iterable classes
+
+A number of Queue, Stack and Heap implementations have different return types in order to align with the built-in PHP interfaces that they implement such as `Iterator` or `IteratorAggregate` etc.
+
+#### Laminas\Stdlib\SplPriorityQueue
+
+This class implements PHP's built-in `\SplPriorityQueue`
+
+- The `insert()` method previously returned `void`. This has been changed to `bool` to align with `\SplPriorityQueue`
+- 

--- a/docs/book/v4/migration/v3-to-v4.md
+++ b/docs/book/v4/migration/v3-to-v4.md
@@ -2,11 +2,19 @@
 
 Version 4 of `laminas-stdlib` contains a number of backwards incompatible changes. This guide is intended to help you upgrade from the version 3 series to version 4.
 
+## New Features
+
 ### Parameter, Property and Return Type Hints Have Been Added Throughout
 
 All classes have been updated to make use of parameter and return types. In general usage, this should not pose too many problems, providing you have been passing the previously documented types to the methods that have changed, however, it is advisable to audit your existing usage of the library for potential type errors. A static analysis tool like Psalm or PHPStan will help you with this.
 
 The addition of property, parameter and return types will cause fatal errors for extending classes that re-define those properties or override changed methods. If you have extended from any classes in laminas-stdlib, you should check that property types and method signatures are compatible and update them if they are not aligned.
+
+## Removed Features
+
+None.
+
+## Signature Changes
 
 ### Breaking Changes to Return Types in Iterable Classes
 
@@ -27,3 +35,7 @@ PHP's built-in `\SplPriorityQueue`, `\SplHeap`, `\SplMinHeap` and other similar 
 
 - `next()` previously returned `false` or the node value at the next index and now returns `void` to align with the `Iterator` interface.
 - `setPriority()` previously returned `self` and now returns `void` for consistency.
+
+## Deprecations
+
+None.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -104,8 +104,19 @@
     <DocblockTypeContradiction>
       <code><![CDATA[throw new Exception\InvalidArgumentException("The extract flag specified is not valid")]]></code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch/>
-    <LessSpecificReturnStatement/>
+    <ImplementedReturnTypeMismatch>
+      <code>TValue|int|array{data: TValue, priority: int}|null</code>
+    </ImplementedReturnTypeMismatch>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[match ($this->extractFlag) {
+            self::EXTR_DATA => current($this->values[$this->maxPriority]),
+            self::EXTR_PRIORITY => $this->maxPriority,
+            self::EXTR_BOTH => [
+                'data'     => current($this->values[$this->maxPriority]),
+                'priority' => $this->maxPriority,
+            ],
+        }]]></code>
+    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$item['data']]]></code>
       <code><![CDATA[$item['priority']]]></code>
@@ -118,13 +129,13 @@
       <code>$item</code>
       <code><![CDATA[$this->maxPriority]]></code>
     </MixedAssignment>
-    <MoreSpecificReturnType/>
+    <MoreSpecificReturnType>
+      <code>TValue|int|array{data: TValue, priority: int}|null</code>
+    </MoreSpecificReturnType>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$this->priorities]]></code>
       <code><![CDATA[$this->priorities]]></code>
       <code><![CDATA[$this->subPriorities]]></code>
-      <code><![CDATA[$this->values]]></code>
-      <code><![CDATA[$this->values]]></code>
       <code><![CDATA[$this->values]]></code>
       <code><![CDATA[$this->values]]></code>
       <code><![CDATA[$this->values]]></code>
@@ -318,7 +329,6 @@
   <file src="test/FastPriorityQueueTest.php">
     <MixedAssignment>
       <code>$item</code>
-      <code>$test[]</code>
       <code>$test[]</code>
       <code>$test[]</code>
       <code>$test[]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -102,20 +102,10 @@
   </file>
   <file src="src/FastPriorityQueue.php">
     <DocblockTypeContradiction>
-      <code>is_int($priority)</code>
       <code><![CDATA[throw new Exception\InvalidArgumentException("The extract flag specified is not valid")]]></code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch>
-      <code>TValue|int|array{data: TValue|false, priority: int|null}|false</code>
-    </ImplementedReturnTypeMismatch>
-    <LessSpecificReturnStatement>
-      <code>$array</code>
-      <code>$value</code>
-    </LessSpecificReturnStatement>
-    <MethodSignatureMustProvideReturnType>
-      <code>serialize</code>
-      <code>unserialize</code>
-    </MethodSignatureMustProvideReturnType>
+    <ImplementedReturnTypeMismatch/>
+    <LessSpecificReturnStatement/>
     <MixedArgument>
       <code><![CDATA[$item['data']]]></code>
       <code><![CDATA[$item['priority']]]></code>
@@ -128,10 +118,7 @@
       <code>$item</code>
       <code><![CDATA[$this->maxPriority]]></code>
     </MixedAssignment>
-    <MoreSpecificReturnType>
-      <code>TValue|int|array{data: TValue, priority: int}|false</code>
-      <code><![CDATA[list<TValue|int|array{data: TValue, priority: int}>]]></code>
-    </MoreSpecificReturnType>
+    <MoreSpecificReturnType/>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$this->priorities]]></code>
       <code><![CDATA[$this->priorities]]></code>
@@ -181,52 +168,17 @@
       <code>setMetadata</code>
     </MissingReturnType>
   </file>
-  <file src="src/PriorityList.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[$node ? $node['data'] : false]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code>current</code>
-    </InvalidFalsableReturnType>
-    <InvalidReturnStatement>
-      <code><![CDATA[$node ? $node['data'] : false]]></code>
-    </InvalidReturnStatement>
-    <MixedReturnTypeCoercion>
-      <code>next</code>
-    </MixedReturnTypeCoercion>
-    <RedundantCastGivenDocblockType>
-      <code>(int) $priority</code>
-      <code>(int) $priority</code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/PriorityQueue.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>serialize</code>
-      <code>unserialize</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="src/SplPriorityQueue.php">
     <DocblockTypeContradiction>
+      <code><![CDATA[! array_key_exists('priority', $item)
+                || ! is_array($item['priority'])]]></code>
+      <code><![CDATA[! is_array($item['priority'])]]></code>
+      <code>is_array($item)</code>
       <code>is_array($priority)</code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch>
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidArgument>
-      <code>$priority</code>
-      <code>$priority</code>
-    </InvalidArgument>
-    <MethodSignatureMismatch>
-      <code>public function insert($datum, $priority)</code>
-    </MethodSignatureMismatch>
-    <MethodSignatureMustProvideReturnType>
-      <code>insert</code>
-      <code>serialize</code>
-      <code>unserialize</code>
-    </MethodSignatureMustProvideReturnType>
-    <MixedArgument>
-      <code><![CDATA[$item['data']]]></code>
-    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$toUnserialize</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/StringUtils.php">
     <DocblockTypeContradiction>
@@ -365,7 +317,6 @@
   </file>
   <file src="test/FastPriorityQueueTest.php">
     <MixedAssignment>
-      <code>$datum</code>
       <code>$item</code>
       <code>$test[]</code>
       <code>$test[]</code>
@@ -396,5 +347,10 @@
       <code><![CDATA[$parameters->foo]]></code>
       <code><![CDATA[$parameters->foof]]></code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="test/SplPriorityQueueTest.php">
+    <MixedPropertyTypeCoercion>
+      <code>new SplPriorityQueue()</code>
+    </MixedPropertyTypeCoercion>
   </file>
 </files>

--- a/src/FastPriorityQueue.php
+++ b/src/FastPriorityQueue.php
@@ -113,8 +113,9 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
      * Insert an element in the queue with a specified priority
      *
      * @param TValue $value
+     * @return true
      */
-    public function insert(mixed $value, int $priority): void
+    public function insert(mixed $value, int $priority): bool
     {
         $this->values[$priority][] = $value;
         if (! isset($this->priorities[$priority])) {
@@ -122,6 +123,8 @@ class FastPriorityQueue implements Iterator, Countable, Serializable
             $this->maxPriority           = $this->maxPriority === null ? $priority : max($priority, $this->maxPriority);
         }
         ++$this->count;
+
+        return true;
     }
 
     /**

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -7,7 +7,7 @@ namespace Laminas\Stdlib;
 use Countable;
 use Exception;
 use Iterator;
-use ReturnTypeWillChange;
+use Traversable;
 
 use function array_map;
 use function current;
@@ -32,49 +32,41 @@ class PriorityList implements Iterator, Countable
      *
      * @var array<TKey, array{data: TValue, priority: int, serial: positive-int|0}>
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
      * Serial assigned to items to preserve LIFO.
      *
      * @var positive-int|0
      */
-    protected $serial = 0;
+    protected int $serial = 0;
 
     // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCapsProperty
 
     /**
      * Serial order mode
-     *
-     * @var integer
      */
-    protected $isLIFO = 1;
+    protected int $isLIFO = 1;
 
     // phpcs:enable
 
     /**
      * Internal counter to avoid usage of count().
-     *
-     * @var int
      */
-    protected $count = 0;
+    protected int $count = 0;
 
     /**
      * Whether the list was already sorted.
-     *
-     * @var bool
      */
-    protected $sorted = false;
+    protected bool $sorted = false;
 
     /**
      * Insert a new item.
      *
      * @param TKey   $name
      * @param TValue $value
-     * @param int    $priority
-     * @return void
      */
-    public function insert($name, mixed $value, $priority = 0)
+    public function insert($name, mixed $value, int $priority = 0): void
     {
         if (! isset($this->items[$name])) {
             $this->count++;
@@ -84,36 +76,31 @@ class PriorityList implements Iterator, Countable
 
         $this->items[$name] = [
             'data'     => $value,
-            'priority' => (int) $priority,
+            'priority' => $priority,
             'serial'   => $this->serial++,
         ];
     }
 
     /**
-     * @param TKey   $name
-     * @param int    $priority
-     * @return $this
+     * @param TKey $name
      * @throws Exception
      */
-    public function setPriority($name, $priority)
+    public function setPriority($name, int $priority): void
     {
         if (! isset($this->items[$name])) {
             throw new Exception("item $name not found");
         }
 
-        $this->items[$name]['priority'] = (int) $priority;
+        $this->items[$name]['priority'] = $priority;
         $this->sorted                   = false;
-
-        return $this;
     }
 
     /**
      * Remove a item.
      *
      * @param  TKey $name
-     * @return void
      */
-    public function remove($name)
+    public function remove($name): void
     {
         if (isset($this->items[$name])) {
             $this->count--;
@@ -124,10 +111,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * Remove all items.
-     *
-     * @return void
      */
-    public function clear()
+    public function clear(): void
     {
         $this->items  = [];
         $this->serial = 0;
@@ -141,10 +126,10 @@ class PriorityList implements Iterator, Countable
      * @param  TKey $name
      * @return TValue|null
      */
-    public function get($name)
+    public function get($name): mixed
     {
         if (! isset($this->items[$name])) {
-            return;
+            return null;
         }
 
         return $this->items[$name]['data'];
@@ -152,10 +137,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * Sort all items.
-     *
-     * @return void
      */
-    protected function sort()
+    protected function sort(): void
     {
         if (! $this->sorted) {
             uasort($this->items, [$this, 'compare']);
@@ -167,9 +150,8 @@ class PriorityList implements Iterator, Countable
      * Compare the priority of two items.
      *
      * @param  array $item1,
-     * @return int
      */
-    protected function compare(array $item1, array $item2)
+    protected function compare(array $item1, array $item2): int
     {
         return $item1['priority'] === $item2['priority']
             ? ($item1['serial'] > $item2['serial'] ? -1 : 1) * $this->isLIFO
@@ -178,11 +160,8 @@ class PriorityList implements Iterator, Countable
 
     /**
      * Get/Set serial order mode
-     *
-     * @param bool|null $flag
-     * @return bool
      */
-    public function isLIFO($flag = null)
+    public function isLIFO(?bool $flag = null): bool
     {
         if ($flag !== null) {
             $isLifo = $flag === true ? 1 : -1;
@@ -199,68 +178,51 @@ class PriorityList implements Iterator, Countable
     /**
      * {@inheritDoc}
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->sort();
         reset($this->items);
     }
 
     /**
-     * {@inheritDoc}
+     * @return TValue|null
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         $this->sorted || $this->sort();
         $node = current($this->items);
 
-        return $node ? $node['data'] : false;
+        return $node ? $node['data'] : null;
     }
 
     /**
-     * {@inheritDoc}
+     * @return TKey|null
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int|string|null
     {
         $this->sorted || $this->sort();
         return key($this->items);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
-        $node = next($this->items);
-
-        return $node ? $node['data'] : false;
+        next($this->items);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return current($this->items) !== false;
     }
 
     /**
-     * @return self
+     * @return Traversable<TKey, TValue>
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return clone $this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }
@@ -268,10 +230,10 @@ class PriorityList implements Iterator, Countable
     /**
      * Return list as array
      *
-     * @param int $flag
+     * @param self::EXTR_* $flag
      * @return array
      */
-    public function toArray($flag = self::EXTR_DATA)
+    public function toArray(int $flag = self::EXTR_DATA): array
     {
         $this->sort();
 

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -65,8 +65,9 @@ class PriorityList implements Iterator, Countable
      *
      * @param TKey   $name
      * @param TValue $value
+     * @return true
      */
-    public function insert($name, mixed $value, int $priority = 0): void
+    public function insert($name, mixed $value, int $priority = 0): bool
     {
         if (! isset($this->items[$name])) {
             $this->count++;
@@ -79,6 +80,8 @@ class PriorityList implements Iterator, Countable
             'priority' => $priority,
             'serial'   => $this->serial++,
         ];
+
+        return true;
     }
 
     /**

--- a/src/PriorityQueue.php
+++ b/src/PriorityQueue.php
@@ -67,16 +67,17 @@ class PriorityQueue implements Countable, IteratorAggregate, Serializable
      * Priority defaults to 1 (low priority) if none provided.
      *
      * @param TValue $data
-     * @return $this
+     * @return true
      */
-    public function insert(mixed $data, int $priority = 1): self
+    public function insert(mixed $data, int $priority = 1): bool
     {
         $this->items[] = [
             'data'     => $data,
             'priority' => $priority,
         ];
         $this->getQueue()->insert($data, $priority);
-        return $this;
+
+        return true;
     }
 
     /**

--- a/src/SplQueue.php
+++ b/src/SplQueue.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
-use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -27,7 +26,7 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @return list<TValue>
      */
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
         foreach ($this as $item) {
@@ -36,13 +35,7 @@ class SplQueue extends \SplQueue implements Serializable
         return $array;
     }
 
-    /**
-     * Serialize
-     *
-     * @return string
-     */
-    #[ReturnTypeWillChange]
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->__serialize());
     }
@@ -52,20 +45,12 @@ class SplQueue extends \SplQueue implements Serializable
      *
      * @return list<TValue>
      */
-    #[ReturnTypeWillChange]
-    public function __serialize()
+    public function __serialize(): array
     {
         return $this->toArray();
     }
 
-    /**
-     * Unserialize
-     *
-     * @param  string $data
-     * @return void
-     */
-    #[ReturnTypeWillChange]
-    public function unserialize($data)
+    public function unserialize(string $data): void
     {
         $toUnserialize = unserialize($data);
         if (! is_array($toUnserialize)) {
@@ -82,10 +67,8 @@ class SplQueue extends \SplQueue implements Serializable
     * Magic method used to rebuild an instance.
     *
     * @param array<array-key, TValue> $data Data array.
-    * @return void
     */
-    #[ReturnTypeWillChange]
-    public function __unserialize($data)
+    public function __unserialize(array $data): void
     {
         foreach ($data as $item) {
             $this->push($item);

--- a/src/SplStack.php
+++ b/src/SplStack.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
-use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -26,7 +25,7 @@ class SplStack extends \SplStack implements Serializable
      *
      * @return list<TValue>
      */
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
         foreach ($this as $item) {
@@ -35,13 +34,7 @@ class SplStack extends \SplStack implements Serializable
         return $array;
     }
 
-    /**
-     * Serialize
-     *
-     * @return string
-     */
-    #[ReturnTypeWillChange]
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->__serialize());
     }
@@ -51,20 +44,12 @@ class SplStack extends \SplStack implements Serializable
      *
      * @return list<TValue>
      */
-    #[ReturnTypeWillChange]
-    public function __serialize()
+    public function __serialize(): array
     {
         return $this->toArray();
     }
 
-    /**
-     * Unserialize
-     *
-     * @param  string $data
-     * @return void
-     */
-    #[ReturnTypeWillChange]
-    public function unserialize($data)
+    public function unserialize(string $data): void
     {
         $toUnserialize = unserialize($data);
         if (! is_array($toUnserialize)) {
@@ -81,10 +66,8 @@ class SplStack extends \SplStack implements Serializable
     * Magic method used to rebuild an instance.
     *
     * @param array<array-key, TValue> $data Data array.
-    * @return void
     */
-    #[ReturnTypeWillChange]
-    public function __unserialize($data)
+    public function __unserialize(array $data): void
     {
         foreach ($data as $item) {
             $this->unshift($item);

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -15,7 +15,7 @@ use function iterator_to_array;
 class PriorityListTest extends TestCase
 {
     /** @var PriorityList<string, mixed> */
-    protected $list;
+    private PriorityList $list;
 
     protected function setUp(): void
     {
@@ -79,7 +79,7 @@ class PriorityListTest extends TestCase
         $this->list->clear();
 
         self::assertCount(0, $this->list);
-        self::assertSame(false, $this->list->current());
+        self::assertNull($this->list->current());
     }
 
     public function testGet(): void
@@ -223,8 +223,11 @@ class PriorityListTest extends TestCase
         $orders2 = [];
 
         foreach ($this->list as $key => $value) {
-            $orders1[$this->list->key()] = $this->list->current();
-            $orders2[$key]               = $value;
+            self::assertNotNull($key);
+            $currentKey = $this->list->key();
+            self::assertNotNull($currentKey);
+            $orders1[$currentKey] = $this->list->current();
+            $orders2[$key]        = $value;
         }
         self::assertEquals($orders1, $orders2);
         self::assertEquals(

--- a/test/PriorityQueueTest.php
+++ b/test/PriorityQueueTest.php
@@ -19,12 +19,12 @@ use function var_export;
 #[Group('Laminas_Stdlib')]
 class PriorityQueueTest extends TestCase
 {
-    /** @var PriorityQueue<string, int> */
+    /** @var PriorityQueue<string> */
     private PriorityQueue $queue;
 
     protected function setUp(): void
     {
-        /** @psalm-var PriorityQueue<string, int> $this->queue */
+        /** @psalm-var PriorityQueue<string> $this->queue */
         $this->queue = new PriorityQueue();
         $this->queue->insert('foo', 3);
         $this->queue->insert('bar', 4);

--- a/test/StaticAnalysis/PriorityQueueGenericsCanBeUnderstood.php
+++ b/test/StaticAnalysis/PriorityQueueGenericsCanBeUnderstood.php
@@ -12,7 +12,7 @@ use function iterator_to_array;
 final class PriorityQueueGenericsCanBeUnderstood
 {
     /**
-     * @param PriorityQueue<string, int> $laminas
+     * @param PriorityQueue<string> $laminas
      */
     public function __construct(private PriorityQueue $laminas)
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

Adds return/property/parameter types to a subset of the iterable types in Stdlib.

I've focussed on queues/stacks here to keep the patch small and easier to review. The intention is to work through other areas of the codebase and add type hints where appropriate in other patches, and update the migration guide with each patch.

This also fixes a bug in `SplPriorityQueue` where a serialisation round trip would cause unexpected insertion order due to the state of `$this->serial` not being updated during un-serialize.
