### PR TITLE
Deprecate array_filter related constants that should have been deprecated with companion method in 3.2

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -330,6 +330,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/ArrayUtilsTest.php">
+    <DeprecatedConstant>
+      <code>ArrayUtils::ARRAY_FILTER_USE_BOTH</code>
+      <code>ArrayUtils::ARRAY_FILTER_USE_KEY</code>
+    </DeprecatedConstant>
     <DeprecatedMethod>
       <code>ArrayUtils::filter($data, $callback, $flag)</code>
       <code><![CDATA[ArrayUtils::filter([], "INVALID")]]></code>

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -35,11 +35,15 @@ abstract class ArrayUtils
 {
     /**
      * Compatibility Flag for ArrayUtils::filter
+     *
+     * @deprecated
      */
     public const ARRAY_FILTER_USE_BOTH = 1;
 
     /**
      * Compatibility Flag for ArrayUtils::filter
+     *
+     * @deprecated
      */
     public const ARRAY_FILTER_USE_KEY = 2;
 


### PR DESCRIPTION
These constants should have been deprecated with ArrayUtils::filter() back in 3.2