### PR TITLE
Minor PHP 8.4 compatibility improvement, Deprecate `ArrayUtils::inArray()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.5",
-        "phpbench/phpbench": "^1.2.14",
-        "phpunit/phpunit": "^10.3.3",
+        "phpbench/phpbench": "^1.2.15",
+        "phpunit/phpunit": "^10.5.8",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.15.0"
+        "vimeo/psalm": "^5.20.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e628fbb1d53887883bae250fe3b4691",
+    "content-hash": "0d90a81d219cadabe4084af5eddc5483",
     "packages": [],
     "packages-dev": [
         {
@@ -1956,16 +1956,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.7",
+            "version": "10.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e5c5b397a95cb0db013270a985726fcae93e61b8"
+                "reference": "08f4fa74d5fbfff1ef22abffee47aaedcaea227e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e5c5b397a95cb0db013270a985726fcae93e61b8",
-                "reference": "e5c5b397a95cb0db013270a985726fcae93e61b8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/08f4fa74d5fbfff1ef22abffee47aaedcaea227e",
+                "reference": "08f4fa74d5fbfff1ef22abffee47aaedcaea227e",
                 "shasum": ""
             },
             "require": {
@@ -2037,7 +2037,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.8"
             },
             "funding": [
                 {
@@ -2053,7 +2053,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-14T16:40:30+00:00"
+            "time": "2024-01-19T07:07:27+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.19.0",
+            "version": "5.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b"
+                "reference": "3f284e96c9d9be6fe6b15c79416e1d1903dcfef4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06b71be009a6bd6d81b9811855d6629b9fe90e1b",
-                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/3f284e96c9d9be6fe6b15c79416e1d1903dcfef4",
+                "reference": "3f284e96c9d9be6fe6b15c79416e1d1903dcfef4",
                 "shasum": ""
             },
             "require": {
@@ -4522,7 +4522,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-01-09T21:02:43+00:00"
+            "time": "2024-01-18T12:15:06+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,9 @@
     displayDetailsOnTestsThatTriggerWarnings="true"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"
+    failOnDeprecation="true"
+    failOnNotice="true"
+    failOnWarning="true"
 >
     <testsuites>
         <testsuite name="laminas-stdlib Test Suite">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="src/AbstractOptions.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($options) && ! $options instanceof Traversable]]></code>
@@ -216,11 +216,7 @@
       <code>$priority</code>
       <code>$priority</code>
     </InvalidArgument>
-    <MethodSignatureMismatch>
-      <code>public function insert($value, $priority)</code>
-    </MethodSignatureMismatch>
     <MethodSignatureMustProvideReturnType>
-      <code>insert</code>
       <code>serialize</code>
       <code>unserialize</code>
     </MethodSignatureMustProvideReturnType>

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -192,13 +192,15 @@ abstract class ArrayUtils
      * non-strict check is implemented. if $strict = -1, the default in_array
      * non-strict behaviour is used.
      *
+     * @deprecated This method will be removed in version 4.0 of this component
+     *
      * @param array $haystack
      * @param int|bool $strict
      * @return bool
      */
     public static function inArray(mixed $needle, array $haystack, $strict = false)
     {
-        if ($strict === false) {
+        if ((bool) $strict === false) {
             if (is_int($needle) || is_float($needle)) {
                 $needle = (string) $needle;
             }

--- a/src/ArrayUtils.php
+++ b/src/ArrayUtils.php
@@ -198,7 +198,7 @@ abstract class ArrayUtils
      */
     public static function inArray(mixed $needle, array $haystack, $strict = false)
     {
-        if (! $strict) {
+        if ($strict === false) {
             if (is_int($needle) || is_float($needle)) {
                 $needle = (string) $needle;
             }

--- a/src/SplPriorityQueue.php
+++ b/src/SplPriorityQueue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+use ReturnTypeWillChange;
 use Serializable;
 use UnexpectedValueException;
 
@@ -41,6 +42,7 @@ class SplPriorityQueue extends \SplPriorityQueue implements Serializable
      * @param  TPriority $priority
      * @return void
      */
+    #[ReturnTypeWillChange] // Inherited return type should be bool
     public function insert($value, $priority)
     {
         if (! is_array($priority)) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

### Description

Updates deps and adds `#[ReturnTypeWillChange]` to `SplPriorityQueue::insert`

I know it's a bit early to worry about 8.4, but I'm already testing some of my projects on 8.4-dev and this deprecation showed up in tests…