### PR TITLE
Update require php to ~8.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "extra": {
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.5",


### PR DESCRIPTION
Makes the laminas-stdlib available for PHP 8.4.