### PR TITLE
Deprecate Http Message and Mvc Interfaces/Classes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -77,6 +77,15 @@
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
   </file>
+  <file src="src/DispatchableInterface.php">
+    <DeprecatedClass>
+      <code><![CDATA[Response|mixed]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[?ResponseInterface]]></code>
+      <code><![CDATA[RequestInterface]]></code>
+    </DeprecatedInterface>
+  </file>
   <file src="src/ErrorHandler.php">
     <InvalidArgument>
       <code><![CDATA[[static::class, 'addError']]]></code>
@@ -152,6 +161,9 @@
     </PossiblyNullOperand>
   </file>
   <file src="src/Message.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Message]]></code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($spec) && ! $spec instanceof Traversable]]></code>
       <code><![CDATA[is_scalar($key)]]></code>
@@ -177,6 +189,11 @@
       <code><![CDATA[setMetadata]]></code>
     </MissingReturnType>
   </file>
+  <file src="src/Parameters.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Parameters]]></code>
+    </DeprecatedInterface>
+  </file>
   <file src="src/PriorityList.php">
     <FalsableReturnStatement>
       <code><![CDATA[$node ? $node['data'] : false]]></code>
@@ -200,6 +217,24 @@
       <code><![CDATA[serialize]]></code>
       <code><![CDATA[unserialize]]></code>
     </MethodSignatureMustProvideReturnType>
+  </file>
+  <file src="src/Request.php">
+    <DeprecatedClass>
+      <code><![CDATA[Message]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[Request]]></code>
+      <code><![CDATA[Request]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="src/Response.php">
+    <DeprecatedClass>
+      <code><![CDATA[Message]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[Response]]></code>
+      <code><![CDATA[Response]]></code>
+    </DeprecatedInterface>
   </file>
   <file src="src/SplPriorityQueue.php">
     <DocblockTypeContradiction>
@@ -322,6 +357,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/ArrayUtilsTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Parameters($array)]]></code>
+    </DeprecatedClass>
     <DeprecatedConstant>
       <code><![CDATA[ArrayUtils::ARRAY_FILTER_USE_BOTH]]></code>
       <code><![CDATA[ArrayUtils::ARRAY_FILTER_USE_KEY]]></code>
@@ -381,7 +419,25 @@
       <code><![CDATA[assertIsArray]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="test/MessageTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+      <code><![CDATA[new Message()]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="test/ParametersTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[$parameters]]></code>
+      <code><![CDATA[new Parameters()]]></code>
+      <code><![CDATA[new Parameters()]]></code>
+      <code><![CDATA[new Parameters()]]></code>
+      <code><![CDATA[new Parameters(['foo' => 'bar'])]]></code>
+    </DeprecatedClass>
     <UndefinedPropertyFetch>
       <code><![CDATA[$parameters->bar]]></code>
       <code><![CDATA[$parameters->baz]]></code>

--- a/src/DispatchableInterface.php
+++ b/src/DispatchableInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
  */
 interface DispatchableInterface
 {

--- a/src/DispatchableInterface.php
+++ b/src/DispatchableInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ */
 interface DispatchableInterface
 {
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,6 +12,12 @@ use function is_array;
 use function is_scalar;
 use function sprintf;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 class Message implements MessageInterface
 {
     /** @var array */

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,7 +13,7 @@ use function is_scalar;
 use function sprintf;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -6,6 +6,12 @@ namespace Laminas\Stdlib;
 
 use Traversable;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\MessageInterface instead
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 interface MessageInterface
 {
     /**

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -7,7 +7,8 @@ namespace Laminas\Stdlib;
 use Traversable;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\MessageInterface instead
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
+ * Use Psr\Http\Message\MessageInterface instead
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -11,6 +11,10 @@ use function http_build_query;
 use function parse_str;
 
 /**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ *
+ * @see https://github.com/laminas/laminas-diactoros as a possible replacement.
+ *
  * @template TKey of array-key
  * @template TValue
  * @template-extends PhpArrayObject<TKey, TValue>

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -14,6 +14,10 @@ use Traversable;
  *     class QueryParams extends ArrayObject implements Parameters {}
  * and have 90% of the functionality
  *
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ *
+ * @see https://github.com/laminas/laminas-diactoros as a possible replacement.
+ *
  * @template TKey
  * @template TValue
  * @template-extends ArrayAccess<TKey, TValue>

--- a/src/ParametersInterface.php
+++ b/src/ParametersInterface.php
@@ -16,8 +16,6 @@ use Traversable;
  *
  * @deprecated since 3.21.0; Will be removed in 4.0.0.
  *
- * @see https://github.com/laminas/laminas-diactoros as a possible replacement.
- *
  * @template TKey
  * @template TValue
  * @template-extends ArrayAccess<TKey, TValue>

--- a/src/Request.php
+++ b/src/Request.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 class Request extends Message implements RequestInterface
 {
     // generic request implementation

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\RequestInterface instead
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
+ * Use Psr\Http\Message\RequestInterface instead
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\RequestInterface instead
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 interface RequestInterface extends MessageInterface
 {
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/Response.php
+++ b/src/Response.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0.
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 class Response extends Message implements ResponseInterface
 {
     // generic response implementation

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Laminas\Stdlib;
 
 /**
- * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\ResponseInterface instead
+ * @deprecated since 3.21.0 due to the retirement of Laminas MVC. Will be removed in 4.0.0.
+ *  Use Psr\Http\Message\ResponseInterface instead
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://github.com/laminas/laminas-diactoros as a possible implementation.

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Stdlib;
 
+/**
+ * @deprecated since 3.21.0; Will be removed in 4.0.0. Use Psr\Http\Message\ResponseInterface instead
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://github.com/laminas/laminas-diactoros as a possible implementation.
+ */
 interface ResponseInterface extends MessageInterface
 {
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

In light of laminas-mvc being retired and its related packages set as security only -

This PR deprecates the Interfaces and classes that laminas-mvc depends on that has been replaced by laminas-diactoros and its PSR7 implementation.

Additional deprecations outside of the strictly PSR7 related interfaces/class:

- ParametersInterface
- Parameters
- DispatchableInterface
